### PR TITLE
Set -fvisibility=hidden and -fvisibility-inlines-hidden for Meson

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -16,7 +16,7 @@ jobs:
         - { name: Linux GCC 12,         os: ubuntu-latest,  compiler: g++12,    cxx: "g++-12",     backend: "ninja",          build: "linux-libstdc++", args: ""}
         - { name: Linux GCC 12 nounity, os: ubuntu-latest,  compiler: g++12,    cxx: "g++-12",     backend: "ninja",          build: "linux-libstdc++", args: "-Dunity_build=false"}
         - { name: Linux GCC 12 shared,  os: ubuntu-latest,  compiler: g++12,    cxx: "g++-12",     backend: "ninja",          build: "linux-libstdc++", args: "--default-library shared"}
-        - { name: Linux Clang 14,       os: ubuntu-latest,  compiler: clang-14, cxx: "clang++-14", backend: "ninja",          build: "linux-libc++", args: ""}
+        - { name: Linux Clang 15,       os: ubuntu-latest,  compiler: clang-15, cxx: "clang++-15", backend: "ninja",          build: "linux-libc++", args: ""}
         - { name: Windows 64,           os: windows-latest, compiler: msvc,     cxx: "cl",         backend: "vs2022 --vsenv", build: "win64-vs2022", args: ""}
         - { name: MacOS,                os: macos-latest,   compiler: clang++,  cxx: "clang++",    backend: "ninja",          build: "osx-libc++", args: ""}
         build-type:

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -16,7 +16,7 @@ jobs:
         - { name: Linux GCC 12,         os: ubuntu-latest,  compiler: g++12,    cxx: "g++-12",     backend: "ninja",          build: "linux-libstdc++", args: ""}
         - { name: Linux GCC 12 nounity, os: ubuntu-latest,  compiler: g++12,    cxx: "g++-12",     backend: "ninja",          build: "linux-libstdc++", args: "-Dunity_build=false"}
         - { name: Linux GCC 12 shared,  os: ubuntu-latest,  compiler: g++12,    cxx: "g++-12",     backend: "ninja",          build: "linux-libstdc++", args: "--default-library shared"}
-        - { name: Linux Clang 15,       os: ubuntu-latest,  compiler: clang-15, cxx: "clang++-15", backend: "ninja",          build: "linux-libc++", args: ""}
+        - { name: Linux Clang 15,       os: ubuntu-latest,  compiler: clang-15, cxx: "clang++-15", backend: "ninja",          build: "linux-libc++", args: "-Dcpp_args='-stdlib=libc++' -Dcpp_link_args='-stdlib=libc++'"}
         - { name: Windows 64,           os: windows-latest, compiler: msvc,     cxx: "cl",         backend: "vs2022 --vsenv", build: "win64-vs2022", args: ""}
         - { name: MacOS,                os: macos-latest,   compiler: clang++,  cxx: "clang++",    backend: "ninja",          build: "osx-libc++", args: ""}
         build-type:
@@ -31,6 +31,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+
+    - name: Setup Clang
+      if: matrix.platform.compiler == 'clang-15' && matrix.platform.os == 'ubuntu-latest'
+      run: sudo apt install clang-15 libc++-15-dev libc++abi-15-dev
 
     - uses: actions/setup-python@v4
       with:

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,26 @@ project('snitch', 'cpp',
   version: '1.2.3'
 )
 
+cxx = meson.get_compiler('cpp')
+compiler_id = cxx.get_id()
+host_system = host_machine.system()
+is_mingw = host_system == 'windows' and cxx.get_id() == 'gcc'
+
+if get_option('default_library') == 'shared'
+  if compiler_id == 'msvc' or is_mingw
+    # Nothing to do; default is already to hide symbols unless exported.
+  elif compiler_id == 'gcc' or compiler_id == 'clang'
+    # Set default visibility to "hidden" so only exported symbols are visible.
+    add_project_arguments(
+      cxx.get_supported_arguments([
+        '-fvisibility=hidden',
+        '-fvisibility-inlines-hidden'
+      ]),
+      language: 'cpp'
+    )
+  endif
+endif
+
 include_dirs = include_directories('.', 'include')
 
 headers = files('include/snitch/snitch.hpp',

--- a/meson.build
+++ b/meson.build
@@ -22,15 +22,6 @@ if get_option('default_library') == 'shared'
   endif
 endif
 
-if cxx.get_id() == 'clang'
-  # Use libc++ when available when compiling with clang.
-  if cxx.find_library('libc++', required: false).found()
-    cpp_arguments += [
-      '-stdlib=libc++',
-    ]
-  endif
-endif
-
 add_project_arguments(cpp_arguments, language : 'cpp')
 add_project_link_arguments(cpp_arguments, language : 'cpp')
 

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,8 @@ project('snitch', 'cpp',
   version: '1.2.3'
 )
 
+cpp_arguments = []
+
 cxx = meson.get_compiler('cpp')
 compiler_id = cxx.get_id()
 host_system = host_machine.system()
@@ -13,15 +15,24 @@ if get_option('default_library') == 'shared'
     # Nothing to do; default is already to hide symbols unless exported.
   elif compiler_id == 'gcc' or compiler_id == 'clang'
     # Set default visibility to "hidden" so only exported symbols are visible.
-    add_project_arguments(
-      cxx.get_supported_arguments([
+    cpp_arguments += cxx.get_supported_arguments([
         '-fvisibility=hidden',
         '-fvisibility-inlines-hidden'
-      ]),
-      language: 'cpp'
-    )
+      ])
   endif
 endif
+
+if cxx.get_id() == 'clang'
+  # Use libc++ when available when compiling with clang.
+  if cxx.find_library('libc++', required: false).found()
+    cpp_arguments += [
+      '-stdlib=libc++',
+    ]
+  endif
+endif
+
+add_project_arguments(cpp_arguments, language : 'cpp')
+add_project_link_arguments(cpp_arguments, language : 'cpp')
 
 include_dirs = include_directories('.', 'include')
 


### PR DESCRIPTION
The PR is related to one of the issues in #116 

> If compiling the library with GCC or clang, we should set -fvisibility=hidden -fvisibility-inlines-hidden (only when building the library, not when consuming it).