### PR TITLE
Fix color codes used even when `--color never` is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The goal of _snitch_ is to be a simple, cheap, non-invasive, and user-friendly t
         - [Built-in reporters](#built-in-reporters)
         - [Overriding the default reporter](#overriding-the-default-reporter)
         - [Registering a new reporter](#registering-a-new-reporter)
+    - [Output colors](#output-colors)
     - [Command-line API](#command-line-api)
     - [Selecting which tests to run](#selecting-which-tests-to-run)
     - [Using your own main function](#using-your-own-main-function)
@@ -861,6 +862,14 @@ This is similar to `REGISTER_REPORTER`, but takes four separate callback functio
 All callback functions are optional except `REPORT`. If a callback is unused, simply specify the function as `{}`. Otherwise, please refer to [Overriding the default reporter](#overriding-the-default-reporter) for instructions on how to specify your own callback functions.
 
 An example can be found in [`include/snitch_reporter_teamcity.hpp`](include/snitch_reporter_teamcity.hpp) / [`src/snitch_reporter_teamcity.cpp`](src/snitch_reporter_teamcity.cpp).
+
+
+### Output colors
+
+_snitch_ is able to use color codes when outputting text to the console. These help with readability, but only when the output is printed directly into a terminal that supports color codes. If the chosen output target does not support color codes (which includes in particular the Windows command prompt, outputting to a file, or some CI frameworks), the output will contain gibberish symbols, e.g., `[1;31merror:[0m missing ...`, hence color codes should be disabled. There are two ways to do this:
+
+ 1. At build-time using `-DSNITCH_DEFAULT_WITH_COLOR=on/off` (CMake) or `-Dsnitch:default_with_color=true/false` (meson). This selects whether color codes are used or not when no specific command-line option is provided to the test executable. This is enabled by default, but you can turn it off if your typical output targets do not support color codes.
+ 2. At run-time using the `--color` (or `--colour-mode`) command-line option (see [the command-line API](#command-line-api) for more information). This allows enabling and disabling color codes for each test run, without rebuilding the tests. This is more useful if your workflow involves some targets which support color codes, and others that do not.
 
 
 ### Command-line API

--- a/include/snitch/snitch_cli.hpp
+++ b/include/snitch/snitch_cli.hpp
@@ -40,7 +40,13 @@ void print(Args&&... args) noexcept {
     console_print(message);
 }
 
-SNITCH_EXPORT void print_help(std::string_view program_name) noexcept;
+struct print_help_settings {
+    bool with_color = true;
+};
+
+SNITCH_EXPORT void print_help(
+    std::string_view           program_name,
+    const print_help_settings& settings = print_help_settings{}) noexcept;
 
 SNITCH_EXPORT std::optional<input> parse_arguments(int argc, const char* const argv[]) noexcept;
 

--- a/src/snitch_cli.cpp
+++ b/src/snitch_cli.cpp
@@ -326,27 +326,27 @@ constexpr expected_arguments expected_args = {
     // For compatibility with Catch2; unused.
     // This is used just to swallow the argument and its parameters.
     // The argument will still be reported as unknown.
-    {{"-s", "--success"},           {},    true},
-    {{"-b", "--break"},             {},    true},
-    {{"-e", "--nothrow"},           {},    true},
-    {{"-i", "--invisibles"},        {},    true},
-    {{"-n", "--name"},              {},    true},
-    {{"-a", "--abort"},             {},    true},
-    {{"-x", "--abortx"},            {"x"}, true},
-    {{"-w", "--warn"},              {"x"}, true},
-    {{"-d", "--durations"},         {"x"}, true},
-    {{"-D", "--min-duration"},      {"x"}, true},
-    {{"-f", "--input-file"},        {"x"}, true},
-    {{"-#", "--filenames-as-tags"}, {"x"}, true},
-    {{"-c", "--section"},           {"x"}, true},
-    {{"--list-listeners"},          {},    true},
-    {{"--order"},                   {"x"}, true},
-    {{"--rng-seed"},                {"x"}, true},
-    {{"--libidentify"},             {},    true},
-    {{"--wait-for-keypress"},       {"x"}, true},
-    {{"--shard-count"},             {"x"}, true},
-    {{"--shard-index"},             {"x"}, true},
-    {{"--allow-running-no-tests"},  {},    true}};
+    {{"-s", "--success"},           {},    true, ""},
+    {{"-b", "--break"},             {},    true, ""},
+    {{"-e", "--nothrow"},           {},    true, ""},
+    {{"-i", "--invisibles"},        {},    true, ""},
+    {{"-n", "--name"},              {},    true, ""},
+    {{"-a", "--abort"},             {},    true, ""},
+    {{"-x", "--abortx"},            {"x"}, true, ""},
+    {{"-w", "--warn"},              {"x"}, true, ""},
+    {{"-d", "--durations"},         {"x"}, true, ""},
+    {{"-D", "--min-duration"},      {"x"}, true, ""},
+    {{"-f", "--input-file"},        {"x"}, true, ""},
+    {{"-#", "--filenames-as-tags"}, {"x"}, true, ""},
+    {{"-c", "--section"},           {"x"}, true, ""},
+    {{"--list-listeners"},          {},    true, ""},
+    {{"--order"},                   {"x"}, true, ""},
+    {{"--rng-seed"},                {"x"}, true, ""},
+    {{"--libidentify"},             {},    true, ""},
+    {{"--wait-for-keypress"},       {"x"}, true, ""},
+    {{"--shard-count"},             {"x"}, true, ""},
+    {{"--shard-index"},             {"x"}, true, ""},
+    {{"--allow-running-no-tests"},  {},    true, ""}};
 // clang-format on
 
 bool parse_color_options(int argc, const char* const argv[]) noexcept {

--- a/src/snitch_cli.cpp
+++ b/src/snitch_cli.cpp
@@ -220,15 +220,11 @@ std::optional<cli::input> parse_arguments(
     return ret;
 }
 
-struct print_help_settings {
-    bool with_color = true;
-};
-
 void print_help(
-    std::string_view           program_name,
-    std::string_view           program_description,
-    const expected_arguments&  expected,
-    const print_help_settings& settings = print_help_settings{}) noexcept {
+    std::string_view                program_name,
+    std::string_view                program_description,
+    const expected_arguments&       expected,
+    const cli::print_help_settings& settings = cli::print_help_settings{}) noexcept {
 
     // Print program description
     cli::print(make_colored(program_description, settings.with_color, color::highlight2), "\n");
@@ -342,10 +338,8 @@ constexpr const char* program_description =
 namespace snitch::cli {
 function_ref<void(std::string_view) noexcept> console_print = &snitch::impl::stdout_print;
 
-void print_help(std::string_view program_name) noexcept {
-    print_help(
-        program_name, impl::program_description, impl::expected_args,
-        {.with_color = impl::with_color_default});
+void print_help(std::string_view program_name, const print_help_settings& settings) noexcept {
+    print_help(program_name, impl::program_description, impl::expected_args, settings);
 }
 
 std::optional<cli::input> parse_arguments(int argc, const char* const argv[]) noexcept {

--- a/src/snitch_cli.cpp
+++ b/src/snitch_cli.cpp
@@ -18,6 +18,7 @@ enum type { optional = 0b00, mandatory = 0b01, repeatable = 0b10 };
 struct expected_argument {
     small_vector<std::string_view, max_arg_names> names;
     std::optional<std::string_view>               value_name;
+    bool                                          ignored = false;
     std::string_view                              description;
     argument_type::type                           type = argument_type::optional;
 };
@@ -25,6 +26,8 @@ struct expected_argument {
 using expected_arguments = small_vector<expected_argument, max_command_line_args>;
 
 struct parser_settings {
+    bool silent     = false;
+    bool tolerant   = false;
     bool with_color = true;
 };
 
@@ -63,7 +66,6 @@ std::optional<cli::input> parse_arguments(
     int                       argc,
     const char* const         argv[],
     const expected_arguments& expected,
-    const expected_arguments& ignored,
     const parser_settings&    settings = parser_settings{}) noexcept {
 
     std::optional<cli::input> ret(std::in_place);
@@ -105,7 +107,7 @@ std::optional<cli::input> parse_arguments(
             for (std::size_t arg_index = 0; arg_index < expected.size(); ++arg_index) {
                 const auto& e = expected[arg_index];
 
-                if (!is_option(e)) {
+                if (e.ignored || !is_option(e)) {
                     continue;
                 }
 
@@ -116,9 +118,11 @@ std::optional<cli::input> parse_arguments(
                 found = true;
 
                 if (expected_found[arg_index] && !is_repeatable(e)) {
-                    cli::print(
-                        make_colored("error:", settings.with_color, color::error),
-                        " duplicate command line argument '", arg, "'\n");
+                    if (!settings.silent) {
+                        cli::print(
+                            make_colored("error:", settings.with_color, color::error),
+                            " duplicate command line argument '", arg, "'\n");
+                    }
                     bad = true;
                     break;
                 }
@@ -127,10 +131,12 @@ std::optional<cli::input> parse_arguments(
 
                 if (has_value(e)) {
                     if (argi + 1 == argc) {
-                        cli::print(
-                            make_colored("error:", settings.with_color, color::error),
-                            " missing value '<", *e.value_name, ">' for command line argument '",
-                            arg, "'\n");
+                        if (!settings.silent) {
+                            cli::print(
+                                make_colored("error:", settings.with_color, color::error),
+                                " missing value '<", *e.value_name,
+                                ">' for command line argument '", arg, "'\n");
+                        }
                         bad = true;
                         break;
                     }
@@ -146,15 +152,21 @@ std::optional<cli::input> parse_arguments(
             }
 
             if (!found) {
-                cli::print(
-                    make_colored("warning:", settings.with_color, color::warning),
-                    " unknown command line argument '", arg, "'\n");
+                if (!settings.silent) {
+                    cli::print(
+                        make_colored("warning:", settings.with_color, color::warning),
+                        " unknown command line argument '", arg, "'\n");
+                }
             }
 
             // Not a supported argument; figure out if this is a known argument (e.g. from Catch2)
             // and whether we need to ignore the next item if it is an option.
-            for (std::size_t arg_index = 0; arg_index < ignored.size(); ++arg_index) {
-                const auto& e = ignored[arg_index];
+            for (std::size_t arg_index = 0; arg_index < expected.size(); ++arg_index) {
+                const auto& e = expected[arg_index];
+
+                if (!e.ignored) {
+                    continue;
+                }
 
                 if (std::find(e.names.cbegin(), e.names.cend(), arg) == e.names.cend()) {
                     continue;
@@ -173,7 +185,7 @@ std::optional<cli::input> parse_arguments(
             for (std::size_t arg_index = 0; arg_index < expected.size(); ++arg_index) {
                 const auto& e = expected[arg_index];
 
-                if (is_option(e)) {
+                if (e.ignored || is_option(e)) {
                     continue;
                 }
 
@@ -189,9 +201,11 @@ std::optional<cli::input> parse_arguments(
             }
 
             if (!found) {
-                cli::print(
-                    make_colored("error:", settings.with_color, color::error),
-                    " too many positional arguments\n");
+                if (!settings.silent) {
+                    cli::print(
+                        make_colored("error:", settings.with_color, color::error),
+                        " too many positional arguments\n");
+                }
                 bad = true;
             }
         }
@@ -199,21 +213,23 @@ std::optional<cli::input> parse_arguments(
 
     for (std::size_t arg_index = 0; arg_index < expected.size(); ++arg_index) {
         const auto& e = expected[arg_index];
-        if (!expected_found[arg_index] && is_mandatory(e)) {
-            if (!is_option(e)) {
-                cli::print(
-                    make_colored("error:", settings.with_color, color::error),
-                    " missing positional argument '<", *e.value_name, ">'\n");
-            } else {
-                cli::print(
-                    make_colored("error:", settings.with_color, color::error), " missing option '<",
-                    e.names.back(), ">'\n");
+        if (!expected_found[arg_index] && is_mandatory(e) && !e.ignored) {
+            if (!settings.silent) {
+                if (!is_option(e)) {
+                    cli::print(
+                        make_colored("error:", settings.with_color, color::error),
+                        " missing positional argument '<", *e.value_name, ">'\n");
+                } else {
+                    cli::print(
+                        make_colored("error:", settings.with_color, color::error),
+                        " missing option '<", e.names.back(), ">'\n");
+                }
             }
             bad = true;
         }
     }
 
-    if (bad) {
+    if (bad && !settings.tolerant) {
         ret.reset();
     }
 
@@ -237,18 +253,20 @@ void print_help(
     }
 
     for (const auto& e : expected) {
-        if (!is_option(e)) {
-            if (!is_mandatory(e) && !is_repeatable(e)) {
-                cli::print(" [<", *e.value_name, ">]");
-            } else if (is_mandatory(e) && !is_repeatable(e)) {
-                cli::print(" <", *e.value_name, ">");
-            } else if (!is_mandatory(e) && is_repeatable(e)) {
-                cli::print(" [<", *e.value_name, ">...]");
-            } else if (is_mandatory(e) && is_repeatable(e)) {
-                cli::print(" <", *e.value_name, ">...");
-            } else {
-                terminate_with("unhandled argument type");
-            }
+        if (e.ignored || is_option(e)) {
+            continue;
+        }
+
+        if (!is_mandatory(e) && !is_repeatable(e)) {
+            cli::print(" [<", *e.value_name, ">]");
+        } else if (is_mandatory(e) && !is_repeatable(e)) {
+            cli::print(" <", *e.value_name, ">");
+        } else if (!is_mandatory(e) && is_repeatable(e)) {
+            cli::print(" [<", *e.value_name, ">...]");
+        } else if (is_mandatory(e) && is_repeatable(e)) {
+            cli::print(" <", *e.value_name, ">...");
+        } else {
+            terminate_with("unhandled argument type");
         }
     }
 
@@ -257,6 +275,10 @@ void print_help(
     // List arguments
     small_string<max_message_length> heading;
     for (const auto& e : expected) {
+        if (e.ignored) {
+            continue;
+        }
+
         heading.clear();
 
         bool success = true;
@@ -290,43 +312,41 @@ void print_help(
 
 // clang-format off
 constexpr expected_arguments expected_args = {
-    {{"-l", "--list-tests"},    {},                         "List tests by name"},
-    {{"--list-tags"},           {},                         "List tags by name"},
-    {{"--list-tests-with-tag"}, {"tag"},                    "List tests by name with a given tag"},
-    {{"--list-reporters"},      {},                         "List available test reporters (see --reporter)"},
-    {{"-r", "--reporter"},      {"reporter[::key=value]*"}, "Choose which reporter to use to output the test results"},
-    {{"-v", "--verbosity"},     {"quiet|normal|high|full"}, "Define how much gets sent to the standard output"},
-    {{"-o", "--out"},           {"path"},                   "Saves output to a file given as 'path'"},
-    {{"--color"},               {"always|default|never"},   "Enable/disable color in output"},
-    {{"--colour-mode"},         {"ansi|default|none"},      "Enable/disable color in output (for compatibility with Catch2)"},
-    {{"-h", "--help"},          {},                         "Print help"},
-    {{},                        {"test regex"},             "A regex to select which test cases to run", argument_type::repeatable}};
-
-// For compatibility with Catch2; unused.
-// This is used just to swallow the argument and its parameters.
-// The argument will still be reported as unknown.
-constexpr expected_arguments ignored_args = {
-    {{"-s", "--success"},           {}, ""},
-    {{"-b", "--break"},             {}, ""},
-    {{"-e", "--nothrow"},           {}, ""},
-    {{"-i", "--invisibles"},        {}, ""},
-    {{"-n", "--name"},              {}, ""},
-    {{"-a", "--abort"},             {}, ""},
-    {{"-x", "--abortx"},            {"x"}, ""},
-    {{"-w", "--warn"},              {"x"}, ""},
-    {{"-d", "--durations"},         {"x"}, ""},
-    {{"-D", "--min-duration"},      {"x"}, ""},
-    {{"-f", "--input-file"},        {"x"}, ""},
-    {{"-#", "--filenames-as-tags"}, {"x"}, ""},
-    {{"-c", "--section"},           {"x"}, ""},
-    {{"--list-listeners"},          {}, ""},
-    {{"--order"},                   {"x"}, ""},
-    {{"--rng-seed"},                {"x"}, ""},
-    {{"--libidentify"},             {}, ""},
-    {{"--wait-for-keypress"},       {"x"}, ""},
-    {{"--shard-count"},             {"x"}, ""},
-    {{"--shard-index"},             {"x"}, ""},
-    {{"--allow-running-no-tests"},  {}, ""}};
+    {{"-l", "--list-tests"},    {},                         false, "List tests by name"},
+    {{"--list-tags"},           {},                         false, "List tags by name"},
+    {{"--list-tests-with-tag"}, {"tag"},                    false, "List tests by name with a given tag"},
+    {{"--list-reporters"},      {},                         false, "List available test reporters (see --reporter)"},
+    {{"-r", "--reporter"},      {"reporter[::key=value]*"}, false, "Choose which reporter to use to output the test results"},
+    {{"-v", "--verbosity"},     {"quiet|normal|high|full"}, false, "Define how much gets sent to the standard output"},
+    {{"-o", "--out"},           {"path"},                   false, "Saves output to a file given as 'path'"},
+    {{"--color"},               {"always|default|never"},   false, "Enable/disable color in output"},
+    {{"--colour-mode"},         {"ansi|default|none"},      false, "Enable/disable color in output (for compatibility with Catch2)"},
+    {{"-h", "--help"},          {},                         false, "Print help"},
+    {{},                        {"test regex"},             false, "A regex to select which test cases to run", argument_type::repeatable},
+    // For compatibility with Catch2; unused.
+    // This is used just to swallow the argument and its parameters.
+    // The argument will still be reported as unknown.
+    {{"-s", "--success"},           {},    true},
+    {{"-b", "--break"},             {},    true},
+    {{"-e", "--nothrow"},           {},    true},
+    {{"-i", "--invisibles"},        {},    true},
+    {{"-n", "--name"},              {},    true},
+    {{"-a", "--abort"},             {},    true},
+    {{"-x", "--abortx"},            {"x"}, true},
+    {{"-w", "--warn"},              {"x"}, true},
+    {{"-d", "--durations"},         {"x"}, true},
+    {{"-D", "--min-duration"},      {"x"}, true},
+    {{"-f", "--input-file"},        {"x"}, true},
+    {{"-#", "--filenames-as-tags"}, {"x"}, true},
+    {{"-c", "--section"},           {"x"}, true},
+    {{"--list-listeners"},          {},    true},
+    {{"--order"},                   {"x"}, true},
+    {{"--rng-seed"},                {"x"}, true},
+    {{"--libidentify"},             {},    true},
+    {{"--wait-for-keypress"},       {"x"}, true},
+    {{"--shard-count"},             {"x"}, true},
+    {{"--shard-index"},             {"x"}, true},
+    {{"--allow-running-no-tests"},  {},    true}};
 // clang-format on
 
 constexpr bool with_color_default = SNITCH_DEFAULT_WITH_COLOR == 1;
@@ -343,9 +363,8 @@ void print_help(std::string_view program_name, const print_help_settings& settin
 }
 
 std::optional<cli::input> parse_arguments(int argc, const char* const argv[]) noexcept {
-    std::optional<cli::input> ret_args = parse_arguments(
-        argc, argv, impl::expected_args, impl::ignored_args,
-        {.with_color = impl::with_color_default});
+    std::optional<cli::input> ret_args =
+        parse_arguments(argc, argv, impl::expected_args, {.with_color = impl::with_color_default});
 
     if (!ret_args) {
         print("\n");

--- a/src/snitch_registry.cpp
+++ b/src/snitch_registry.cpp
@@ -694,7 +694,7 @@ bool registry::run_tests(std::string_view run_name) noexcept {
 namespace {
 bool run_tests_impl(registry& r, const cli::input& args) noexcept {
     if (get_option(args, "--help")) {
-        cli::print_help(args.executable);
+        cli::print_help(args.executable, {.with_color = r.with_color});
         return true;
     }
 

--- a/tests/runtime_tests/cli.cpp
+++ b/tests/runtime_tests/cli.cpp
@@ -208,6 +208,28 @@ TEST_CASE("parse arguments multiple positional", "[cli]") {
     CHECK(console.messages.empty());
 }
 
+TEST_CASE("parse arguments error no color", "[cli]") {
+    console_output_catcher console;
+
+    SECTION("duplicate arg") {
+        const arg_vector args = {"test", "--color", "never", "--color", "always"};
+        snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        CHECK(!contains_color_codes(console.messages));
+    }
+
+    SECTION("missing value") {
+        const arg_vector args = {"test", "--color", "never", "--verbosity"};
+        snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        CHECK(!contains_color_codes(console.messages));
+    }
+
+    SECTION("unknown arg") {
+        const arg_vector args = {"test", "--color", "never", "--foobar"};
+        snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        CHECK(!contains_color_codes(console.messages));
+    }
+}
+
 TEST_CASE("get option", "[cli]") {
     const arg_vector args = {"test", "--help", "--verbosity", "high"};
     auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -883,6 +883,13 @@ TEST_CASE("run tests cli", "[registry][cli]") {
         CHECK_RUN(false, 5u, 3u, 0u, 1u, 3u, 3u, 0u);
 #endif
     }
+}
+
+TEST_CASE("print help cli", "[registry][cli]") {
+    mock_framework framework;
+    framework.setup_reporter();
+    register_tests(framework);
+    console_output_catcher console;
 
     SECTION("--help") {
         const arg_vector args = {"test", "--help"};
@@ -893,6 +900,16 @@ TEST_CASE("run tests cli", "[registry][cli]") {
         CHECK(framework.events.empty());
         CHECK(framework.get_num_runs() == 0u);
         CHECK(console.messages == contains_substring("test [options...]"));
+    }
+
+    SECTION("--help no color") {
+        const arg_vector args = {"test", "--help", "--color", "never"};
+        auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
+        framework.registry.run_tests(*input);
+
+        snitch::impl::stdout_print(console.messages);
+        CHECK(!contains_color_codes(console.messages));
     }
 }
 

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -874,6 +874,7 @@ TEST_CASE("run tests cli", "[registry][cli]") {
     SECTION("no argument") {
         const arg_vector args = {"test"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -886,6 +887,7 @@ TEST_CASE("run tests cli", "[registry][cli]") {
     SECTION("--help") {
         const arg_vector args = {"test", "--help"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
         CHECK(framework.events.empty());
@@ -903,6 +905,7 @@ TEST_CASE("list stuff cli", "[registry][cli]") {
     SECTION("--list-tests") {
         const arg_vector args = {"test", "--list-tests"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
         REQUIRE(framework.events.size() == 15u);
@@ -915,6 +918,7 @@ TEST_CASE("list stuff cli", "[registry][cli]") {
     SECTION("--list-tests filtered") {
         const arg_vector args = {"test", "--list-tests", "how*"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
         REQUIRE(framework.events.size() == 6u);
@@ -931,6 +935,7 @@ TEST_CASE("list stuff cli", "[registry][cli]") {
     SECTION("--list-tags") {
         const arg_vector args = {"test", "--list-tags"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
         CHECK(framework.events.empty());
@@ -944,6 +949,7 @@ TEST_CASE("list stuff cli", "[registry][cli]") {
     SECTION("--list-tests-with-tag") {
         const arg_vector args = {"test", "--list-tests-with-tag", "[other_tag]"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
         REQUIRE(framework.events.size() == 4u);
@@ -956,6 +962,7 @@ TEST_CASE("list stuff cli", "[registry][cli]") {
     SECTION("--list-reporters") {
         const arg_vector args = {"test", "--list-reporters"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
 
         SECTION("default") {
             framework.registry.run_tests(*input);
@@ -990,6 +997,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter") {
         const arg_vector args = {"test", "how many*"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -1002,6 +1010,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter multiple AND") {
         const arg_vector args = {"test", "how many*", "*templated*"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -1014,6 +1023,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter multiple OR") {
         const arg_vector args = {"test", "how many*,*are you"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -1026,6 +1036,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter exclusion") {
         const arg_vector args = {"test", "~*fail"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -1038,6 +1049,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter hidden") {
         const arg_vector args = {"test", "hidden test*"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -1050,6 +1062,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter tag") {
         const arg_vector args = {"test", "[skipped]"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
         CHECK_RUN(true, 1u, 0u, 0u, 1u, 0u, 0u, 0u);
@@ -1058,6 +1071,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter multiple tags") {
         const arg_vector args = {"test", "[other_tag][tag]"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -1070,6 +1084,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter tag AND name") {
         const arg_vector args = {"test", "[tag]", "*many lights"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS
@@ -1082,6 +1097,7 @@ TEST_CASE("run tests filtered cli", "[registry][cli]") {
     SECTION("test filter tag OR name") {
         const arg_vector args = {"test", "[other_tag],how are*"};
         auto input = snitch::cli::parse_arguments(static_cast<int>(args.size()), args.data());
+        framework.registry.configure(*input);
         framework.registry.run_tests(*input);
 
 #if SNITCH_WITH_EXCEPTIONS

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -12,3 +12,19 @@
 #    define SNITCH_EXPORT
 #    include "snitch_main.cpp"
 #endif
+
+bool contains_color_codes(std::string_view msg) noexcept {
+    constexpr std::array codes = {snitch::impl::color::error,      snitch::impl::color::warning,
+                                  snitch::impl::color::status,     snitch::impl::color::fail,
+                                  snitch::impl::color::skipped,    snitch::impl::color::pass,
+                                  snitch::impl::color::highlight1, snitch::impl::color::highlight2,
+                                  snitch::impl::color::reset};
+
+    for (const auto c : codes) {
+        if (msg.find(c) != std::string_view::npos) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -101,3 +101,5 @@ struct filldata<T*> {
 #    define SNITCH_WARNING_DISABLE_PRECEDENCE
 #    define SNITCH_WARNING_DISABLE_ASSIGNMENT
 #endif
+
+bool contains_color_codes(std::string_view msg) noexcept;


### PR DESCRIPTION
This PR fixes #147:
 - The `registry` class now forwards its `with_color` option to the `print_help()` function, so `./tests --color never --help` prints the help text without color codes.
 - The command-line parser now parses arguments in two passes. The first pass looks only at color options, silently ignoring any problem, then changes the color configuration as specified. The second pass looks again at all options, and reports any problem using the color options configured in the first pass. This means that, for example, `./tests --color never --verbosity babbling` will report the unknown `babbling` value without using color codes.

Note that, in both cases, argument ordering remains irrelevant, so `--color never --help` and `--help --color never` produces the same output.