### PR TITLE
feature switch for thread_local variables and multi-threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SNITCH_MAX_PATH_LENGTH          1024 CACHE STRING "Maximum length of a file 
 # Feature toggles.
 set(SNITCH_DEFINE_MAIN                     ON  CACHE BOOL "Define main() in snitch -- disable to provide your own main() function.")
 set(SNITCH_WITH_EXCEPTIONS                 ON  CACHE BOOL "Use exceptions in snitch implementation -- will be forced OFF if exceptions are not available.")
-set(SNITCH_WITH_MULTITHREADING             ON  CACHE BOOL "Multi-threading support and thread local variables -- disable if needed.")
+set(SNITCH_WITH_MULTITHREADING             ON  CACHE BOOL "Make the testing framework thread-safe -- disable if multithreading is not needed.")
 set(SNITCH_WITH_TIMINGS                    ON  CACHE BOOL "Measure the time taken by each test case -- disable to speed up tests.")
 set(SNITCH_WITH_SHORTHAND_MACROS           ON  CACHE BOOL "Use short names for test macros -- disable if this causes conflicts.")
 set(SNITCH_CONSTEXPR_FLOAT_USE_BITCAST     ON  CACHE BOOL "Use std::bit_cast if available to implement exact constexpr float-to-string conversion.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SNITCH_MAX_PATH_LENGTH          1024 CACHE STRING "Maximum length of a file 
 # Feature toggles.
 set(SNITCH_DEFINE_MAIN                     ON  CACHE BOOL "Define main() in snitch -- disable to provide your own main() function.")
 set(SNITCH_WITH_EXCEPTIONS                 ON  CACHE BOOL "Use exceptions in snitch implementation -- will be forced OFF if exceptions are not available.")
+set(SNITCH_WITH_MULTITHREADING             ON  CACHE BOOL "Multi-threading support and thread local variables -- disable if needed.")
 set(SNITCH_WITH_TIMINGS                    ON  CACHE BOOL "Measure the time taken by each test case -- disable to speed up tests.")
 set(SNITCH_WITH_SHORTHAND_MACROS           ON  CACHE BOOL "Use short names for test macros -- disable if this causes conflicts.")
 set(SNITCH_CONSTEXPR_FLOAT_USE_BITCAST     ON  CACHE BOOL "Use std::bit_cast if available to implement exact constexpr float-to-string conversion.")

--- a/include/snitch/snitch_config.hpp.config
+++ b/include/snitch/snitch_config.hpp.config
@@ -77,6 +77,9 @@
 #if !defined(SNITCH_WITH_CATCH2_REPORTER)
 #cmakedefine01 SNITCH_WITH_CATCH2_REPORTER
 #endif
+#if !defined(SNITCH_WITH_MULTITHREADING)
+#cmakedefine01 SNITCH_WITH_MULTITHREADING
+#endif
 #if !defined(SNITCH_SHARED_LIBRARY)
 #cmakedefine01 SNITCH_SHARED_LIBRARY
 #endif
@@ -95,6 +98,12 @@
 #if defined(SNITCH_EXCEPTIONS_NOT_AVAILABLE)
 #    undef SNITCH_WITH_EXCEPTIONS
 #    define SNITCH_WITH_EXCEPTIONS 0
+#endif
+
+#if defined(SNITCH_WITH_MULTITHREADING)
+#    define SNITCH_THREAD_LOCAL thread_local
+#else
+#    define SNITCH_THREAD_LOCAL
 #endif
 
 #if !defined(__cpp_lib_bit_cast)

--- a/include/snitch/snitch_config.hpp.config
+++ b/include/snitch/snitch_config.hpp.config
@@ -100,7 +100,7 @@
 #    define SNITCH_WITH_EXCEPTIONS 0
 #endif
 
-#if defined(SNITCH_WITH_MULTITHREADING)
+#if SNITCH_WITH_MULTITHREADING
 #    define SNITCH_THREAD_LOCAL thread_local
 #else
 #    define SNITCH_THREAD_LOCAL

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,7 +15,7 @@ option('max_path_length'          ,type: 'integer' ,value: 1024, description: 'M
 # Feature toggles.
 option('define_main'                     ,type: 'boolean' ,value: true, description: 'Define main() in snitch -- disable to provide your own main() function.')
 option('with_exceptions'                 ,type: 'boolean' ,value: true, description: 'Use exceptions in snitch implementation -- will be forced OFF if exceptions are not available.')
-option('with_multithreading'             ,type: 'boolean', value: true, description: 'Multi-threading support and thread local variables -- disable if needed.')
+option('with_multithreading'             ,type: 'boolean', value: true, description: 'Make the testing framework thread-safe -- disable if multithreading is not needed.')
 option('with_timings'                    ,type: 'boolean' ,value: true, description: 'Measure the time taken by each test case -- disable to speed up tests.')
 option('with_shorthand_macros'           ,type: 'boolean' ,value: true, description: 'Use short names for test macros -- disable if this causes conflicts.')
 option('constexpr_float_use_bitcast'     ,type: 'boolean' ,value: true, description: 'Use std::bit_cast if available to implement exact constexpr float-to-string conversion.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,6 +15,7 @@ option('max_path_length'          ,type: 'integer' ,value: 1024, description: 'M
 # Feature toggles.
 option('define_main'                     ,type: 'boolean' ,value: true, description: 'Define main() in snitch -- disable to provide your own main() function.')
 option('with_exceptions'                 ,type: 'boolean' ,value: true, description: 'Use exceptions in snitch implementation -- will be forced OFF if exceptions are not available.')
+option('with_multithreading'             ,type: 'boolean', value: true, description: 'Multi-threading support and thread local variables -- disable if needed.')
 option('with_timings'                    ,type: 'boolean' ,value: true, description: 'Measure the time taken by each test case -- disable to speed up tests.')
 option('with_shorthand_macros'           ,type: 'boolean' ,value: true, description: 'Use short names for test macros -- disable if this causes conflicts.')
 option('constexpr_float_use_bitcast'     ,type: 'boolean' ,value: true, description: 'Use std::bit_cast if available to implement exact constexpr float-to-string conversion.')

--- a/snitch/meson.build
+++ b/snitch/meson.build
@@ -34,6 +34,7 @@ conf_data = configuration_data({
 
   'SNITCH_DEFINE_MAIN'                     : get_option('define_main').to_int(),
   'SNITCH_WITH_EXCEPTIONS'                 : get_option('with_exceptions').to_int(),
+  'SNITCH_WITH_MULTITHREADING'             : get_option('with_multithreading').to_int(),
   'SNITCH_WITH_TIMINGS'                    : get_option('with_timings').to_int(),
   'SNITCH_WITH_SHORTHAND_MACROS'           : get_option('with_shorthand_macros').to_int(),
   'SNITCH_CONSTEXPR_FLOAT_USE_BITCAST'     : get_option('constexpr_float_use_bitcast').to_int(),

--- a/src/snitch_test_data.cpp
+++ b/src/snitch_test_data.cpp
@@ -6,7 +6,7 @@
 
 namespace snitch::impl {
 namespace {
-thread_local test_state* thread_current_test = nullptr;
+SNITCH_THREAD_LOCAL test_state* thread_current_test = nullptr;
 }
 
 test_state& get_current_test() noexcept {


### PR DESCRIPTION
thread local variables will trigger a memory allocation on a bare metal system. When running tests on a single thread, or a system without threads, there is no benefit to using a `thread_local` variable. As discussed in  #158.

This change creates a feature flag to control if snitch should be compiled with support for threading. A macro `SNITCH_THREAD_LOCAL` is defined in the config header that resolves to nothing when the feature flag is disabled, or `thread_local` when it is enabled. The feature flag is enabled by default to preserve existing behavior.

I names the feature flag `SNITCH_WITH_MULTITHREADING` to let it be used for any future threading features as well. If you want a more granular option that is an easy change.

I updated the CMake project file, and the meson options. I don't use meson so someone double checking my work there would be great. The change seems simple enough though 😄 
