### PR TITLE
Match output of catch2 when listing tests with default reporter

### DIFF
--- a/src/snitch_reporter_console.cpp
+++ b/src/snitch_reporter_console.cpp
@@ -171,14 +171,19 @@ struct default_reporter_functor {
         print_message(r, e.data);
     }
 
-    void operator()(const snitch::event::list_test_run_started&) const noexcept {}
+    void operator()(const snitch::event::list_test_run_started&) const noexcept {
+        r.print("Matching test cases:\n");
+    }
 
     void operator()(const snitch::event::list_test_run_ended&) const noexcept {}
 
     void operator()(const snitch::event::test_case_listed& e) {
         small_string<max_test_name_length> full_name;
         make_full_name(full_name, e.id);
-        r.print(full_name, "\n");
+        r.print("  ", full_name, "\n");
+        if (!e.id.tags.empty()) {
+            r.print("      ", e.id.tags, "\n");
+        }
     }
 };
 } // namespace

--- a/tests/approval_tests/data/expected/reporter_console_list_tests
+++ b/tests/approval_tests/data/expected/reporter_console_list_tests
@@ -1,42 +1,55 @@
-test pass
-test fail
-test mayfail good pass
-test mayfail bad pass
-test shouldfail good fail
-test shouldfail bad pass
-test no tags pass
-test no tags fail
-typed test no tags pass <int>
-typed test no tags pass <float>
-typed test no tags fail <int>
-typed test no tags fail <float>
-typed test with tags pass <int>
-typed test with tags pass <float>
-typed test with tags fail <int>
-typed test with tags fail <float>
-test fixture pass
-test fixture fail
-test SUCCEED pass
-test FAIL fail
-test expression pass
-test expression fail
-test long expression pass
-test long expression fail
-test too long expression pass
-test too long expression fail
-test too long message pass
-test too long message fail
-test NOTHROW pass
-test NOTHROW fail
-test THROW pass
-test THROW fail
-test unexpected throw fail
-test unexpected throw in section fail
-test unexpected throw in check fail
-test unexpected throw in check & section fail
-test SKIP
-test INFO
-test multiple INFO
-test SECTION
-test multiple SECTION
-test SECTION & INFO
+Matching test cases:
+  test pass
+      [tag2][tag1]
+  test fail
+      [tag2][tag1]
+  test mayfail good pass
+      [tag2][tag1][!mayfail]
+  test mayfail bad pass
+      [tag2][tag1][!mayfail]
+  test shouldfail good fail
+      [tag2][tag1][!shouldfail]
+  test shouldfail bad pass
+      [tag2][tag1][!shouldfail]
+  test no tags pass
+  test no tags fail
+  typed test no tags pass <int>
+  typed test no tags pass <float>
+  typed test no tags fail <int>
+  typed test no tags fail <float>
+  typed test with tags pass <int>
+      [tag1]
+  typed test with tags pass <float>
+      [tag1]
+  typed test with tags fail <int>
+      [tag1]
+  typed test with tags fail <float>
+      [tag1]
+  test fixture pass
+      [tag with space]
+  test fixture fail
+      [tag with space]
+  test SUCCEED pass
+  test FAIL fail
+  test expression pass
+  test expression fail
+  test long expression pass
+  test long expression fail
+  test too long expression pass
+  test too long expression fail
+  test too long message pass
+  test too long message fail
+  test NOTHROW pass
+  test NOTHROW fail
+  test THROW pass
+  test THROW fail
+  test unexpected throw fail
+  test unexpected throw in section fail
+  test unexpected throw in check fail
+  test unexpected throw in check & section fail
+  test SKIP
+  test INFO
+  test multiple INFO
+  test SECTION
+  test multiple SECTION
+  test SECTION & INFO

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -583,7 +583,10 @@ TEST_CASE("list tests", "[registry]") {
             CAPTURE(tag);
             console.messages.clear();
 
+            const auto header = "Matching test cases:\n"sv;
+
             framework.registry.list_tests_with_tag(tag);
+            CHECK(console.messages == contains_substring(header));
             if (tag == "[tag]"sv) {
                 CHECK(console.messages == contains_substring("how are you"));
                 CHECK(console.messages == contains_substring("how many lights"));
@@ -618,7 +621,7 @@ TEST_CASE("list tests", "[registry]") {
                 CHECK(console.messages == contains_substring("how many templated lights"));
                 CHECK(console.messages == contains_substring("hidden test 1"));
             } else if (tag == "[wrong_tag]"sv || tag == "[.hidden]"sv) {
-                CHECK(console.messages.empty());
+                CHECK(console.messages == header);
             }
         }
     }


### PR DESCRIPTION
My team uses Clion and while transitioning our libraries to snitch from Catch2 I noticed CLion choking on the tests. Clion has built in Catch2 support, and in the readme snitch claims to support Clion via this.

I modified the snitch main function to write the value of `argv` to a file, and saw that clion calls the test binary twice:
 - before running tests with `--list-tests --order lex ~[.]`
 - run the tests with `-r xml -d yes --order lex`

I compared the output with the list tests command between the latest Catch2 and snitch. I copied a representation of the difference at the bottom of this description. But the key differences are:

1. tests aren't ordered
2. no header text "Matching test cases:"
3. no final "132 matching test cases"
4. test names aren't indented
5. no tags output for each test

Of these items Clion at least only seems to care about 2, 4, and 5.

Adding the test count at the end doesn't matter to Clion and would be a much larger change. I have two branches in my repo here I attempted it and it was either:
- [Static variable in the default reported struct](https://github.com/snitch-org/snitch/commit/1a00e1a25ce2d4208ea1a0b283e14e2703d0c4c9). Which isn't very nice.
- [change default reporter to a struct](https://github.com/snitch-org/snitch/commit/d9ccce756f82d66ffefd042000624752f058f6b3) with a counter variable as member. A large change that I didn't actually get to work.

## Catch2
```
$ unit-tests-catch2.exe --list-tests --order lex ~[.]
Matching test cases:
  Asserts and contracts
      [assert]
  COBS framing
      [cobs][ranges]
  COBS unframing
      [cobs][ranges]
  CRC Algorithm
  GPS <-> UTC Conversions
  block_allocator
      [blocks][memory][pool]
  block_allocator custom alignment
      [blocks][memory][pool]
  inplace_function
      [functional][larid]
  is_scoped_enum
      [c++23][type_traits]
  memory_pool_external
      [memory][pool]
  memory_resource
      [larid][memory_resource]
  ........... many more tests I won't waste space on .......
132 matching test cases
```

### No test listed
```
$ unit-tests-catch2.exe --list-tests --order lex [.]
Matching test cases:
0 matching test cases
```

## Snitch
```
$ unit-tests-snitch.exe --list-tests --order lex ~[.]
warning: unknown command line argument '--order'
COBS framing
COBS unframing
basic_netbuf
empty ispanstream
non-empty ispanstream
empty istreambuf_iterator
empty ostreambuf_iterator
memory_resource
block_allocator
block_allocator custom alignment
memory_pool_external
```