### PR TITLE
Catch2 emulation: list tests has a footer

### DIFF
--- a/include/snitch/snitch_registry.hpp
+++ b/include/snitch/snitch_registry.hpp
@@ -113,19 +113,7 @@ class registry {
     std::optional<impl::file_writer> file_writer;
 
     // the default console reporter
-    static inline snitch::reporter::console::reporter console_reporter;
-
-    // static functions to allow console reporter to be registered
-    static void console_init(snitch::registry& r) noexcept {
-        console_reporter = snitch::reporter::console::reporter(r);
-    }
-    static bool console_config(snitch::registry& r, std::string_view k, std::string_view v) noexcept {
-        return console_reporter.configure(r, k, v);
-    }
-    static void console_report(const snitch::registry& r, const snitch::event::data& e) noexcept {
-        console_reporter.report(r, e);
-    }
-    static void console_finish(snitch::registry&) noexcept {}
+    snitch::reporter::console::reporter console_reporter;
 
 public:
     enum class verbosity { quiet, normal, high, full } verbose = verbosity::normal;
@@ -138,8 +126,9 @@ public:
     using finish_report_function     = snitch::finish_report_function;
 
     print_function  print_callback  = &snitch::impl::stdout_print;
-    report_function report_callback = &console_report;
-    finish_report_function finish_callback = &console_finish;
+    report_function report_callback = {
+        console_reporter, snitch::constant<&snitch::reporter::console::reporter::report>{}};
+    finish_report_function finish_callback = [](registry&) noexcept {};
 
     // Internal API; do not use.
     template<typename T>

--- a/include/snitch/snitch_registry.hpp
+++ b/include/snitch/snitch_registry.hpp
@@ -116,7 +116,9 @@ class registry {
     static inline snitch::reporter::console::reporter console_reporter;
 
     // static functions to allow console reporter to be registered
-    static void console_init(snitch::registry&) noexcept {}
+    static void console_init(snitch::registry& r) noexcept {
+        console_reporter = snitch::reporter::console::reporter(r);
+    }
     static bool console_config(snitch::registry& r, std::string_view k, std::string_view v) noexcept {
         return console_reporter.configure(r, k, v);
     }

--- a/include/snitch/snitch_reporter_console.hpp
+++ b/include/snitch/snitch_reporter_console.hpp
@@ -7,11 +7,15 @@
 #include <string_view>
 
 namespace snitch::reporter::console {
-SNITCH_EXPORT void initialize(registry& r) noexcept;
+struct reporter {
+    std::size_t counter = 0;
 
-SNITCH_EXPORT bool configure(registry&, std::string_view, std::string_view) noexcept;
+    SNITCH_EXPORT explicit reporter(registry& r) noexcept;
 
-SNITCH_EXPORT void report(const registry& r, const snitch::event::data& event) noexcept;
+    SNITCH_EXPORT bool configure(registry&, std::string_view, std::string_view) noexcept;
+
+    SNITCH_EXPORT void report(const registry& r, const snitch::event::data& event) noexcept;
+};
 } // namespace snitch::reporter::console
 
 #endif

--- a/include/snitch/snitch_reporter_console.hpp
+++ b/include/snitch/snitch_reporter_console.hpp
@@ -12,8 +12,6 @@ struct reporter {
 
     reporter() = default;
 
-    SNITCH_EXPORT explicit reporter(registry& r) noexcept;
-
     SNITCH_EXPORT void init(registry& r) noexcept;
 
     SNITCH_EXPORT bool configure(registry&, std::string_view, std::string_view) noexcept;

--- a/include/snitch/snitch_reporter_console.hpp
+++ b/include/snitch/snitch_reporter_console.hpp
@@ -10,6 +10,8 @@ namespace snitch::reporter::console {
 struct reporter {
     std::size_t counter = 0;
 
+    reporter() = default;
+
     SNITCH_EXPORT explicit reporter(registry& r) noexcept;
 
     SNITCH_EXPORT bool configure(registry&, std::string_view, std::string_view) noexcept;

--- a/include/snitch/snitch_reporter_console.hpp
+++ b/include/snitch/snitch_reporter_console.hpp
@@ -14,6 +14,8 @@ struct reporter {
 
     SNITCH_EXPORT explicit reporter(registry& r) noexcept;
 
+    SNITCH_EXPORT void init(registry& r) noexcept;
+
     SNITCH_EXPORT bool configure(registry&, std::string_view, std::string_view) noexcept;
 
     SNITCH_EXPORT void report(const registry& r, const snitch::event::data& event) noexcept;

--- a/src/snitch_registry.cpp
+++ b/src/snitch_registry.cpp
@@ -336,6 +336,10 @@ std::string_view registry::add_reporter(
     return name;
 }
 
+std::string_view registry::add_console_reporter() {
+    return add_reporter("console", console_init, console_config, console_report, console_finish);
+}
+
 const char*
 registry::add_impl(const test_id& id, const source_location& location, impl::test_ptr func) {
     if (test_list.available() == 0u) {
@@ -1019,3 +1023,6 @@ small_vector_span<const registered_reporter> registry::reporters() const noexcep
 
 constinit registry tests;
 } // namespace snitch
+
+static const std::string_view console_reporter_id [[maybe_unused]] =
+    snitch::tests.add_console_reporter();

--- a/src/snitch_registry.cpp
+++ b/src/snitch_registry.cpp
@@ -337,7 +337,12 @@ std::string_view registry::add_reporter(
 }
 
 std::string_view registry::add_console_reporter() {
-    return add_reporter("console", console_init, console_config, console_report, console_finish);
+    using reporter_type = snitch::reporter::console::reporter;
+    return add_reporter("console",
+        initialize_report_function{console_reporter, snitch::constant<&reporter_type::init>{}},
+        configure_report_function{console_reporter, snitch::constant<&reporter_type::configure>{}},
+        {console_reporter, snitch::constant<&snitch::reporter::console::reporter::report>{}},
+        {});
 }
 
 const char*

--- a/src/snitch_reporter_console.cpp
+++ b/src/snitch_reporter_console.cpp
@@ -88,6 +88,10 @@ void print_message(const registry& r, const assertion_data& data) {
 
 reporter::reporter(registry&) noexcept {}
 
+void reporter::init(registry&) noexcept {
+    counter = 0;
+}
+
 bool reporter::configure(registry& r, std::string_view option, std::string_view value) noexcept {
     if (option == "color") {
         parse_color_option(r, value);

--- a/src/snitch_reporter_console.cpp
+++ b/src/snitch_reporter_console.cpp
@@ -84,113 +84,11 @@ void print_message(const registry& r, const assertion_data& data) {
             }},
         data);
 }
-
-struct default_reporter_functor {
-    const registry& r;
-
-    void operator()(const snitch::event::test_run_started& e) const noexcept {
-        r.print(
-            make_colored("starting ", r.with_color, color::highlight2),
-            make_colored(e.name, r.with_color, color::highlight1),
-            make_colored(" with ", r.with_color, color::highlight2),
-            make_colored("snitch v" SNITCH_FULL_VERSION "\n", r.with_color, color::highlight1));
-        r.print("==========================================\n");
-    }
-
-    void operator()(const snitch::event::test_run_ended& e) const noexcept {
-        r.print("==========================================\n");
-
-        if (e.success) {
-            r.print(
-                make_colored("success:", r.with_color, color::pass), " all tests passed (",
-                e.run_count, " test cases, ", e.assertion_count, " assertions");
-        } else {
-            r.print(
-                make_colored("error:", r.with_color, color::fail), " ",
-                (e.fail_count == e.run_count ? "all" : "some"), " tests failed (", e.fail_count,
-                " out of ", e.run_count, " test cases, ", e.assertion_count, " assertions");
-        }
-
-        if (e.skip_count > 0) {
-            r.print(", ", e.skip_count, " test cases skipped");
-        }
-
-#if SNITCH_WITH_TIMINGS
-        r.print(", ", e.duration, " seconds");
-#endif
-
-        r.print(")\n");
-    }
-
-    void operator()(const snitch::event::test_case_started& e) const noexcept {
-        small_string<max_test_name_length> full_name;
-        make_full_name(full_name, e.id);
-
-        r.print(
-            make_colored("starting:", r.with_color, color::status), " ",
-            make_colored(full_name, r.with_color, color::highlight1), " at ", e.location.file, ":",
-            e.location.line, "\n");
-    }
-
-    void operator()(const snitch::event::test_case_ended& e) const noexcept {
-        small_string<max_test_name_length> full_name;
-        make_full_name(full_name, e.id);
-
-#if SNITCH_WITH_TIMINGS
-        r.print(
-            make_colored("finished:", r.with_color, color::status), " ",
-            make_colored(full_name, r.with_color, color::highlight1), " (", e.duration, "s)\n");
-#else
-        r.print(
-            make_colored("finished:", r.with_color, color::status), " ",
-            make_colored(full_name, r.with_color, color::highlight1), "\n");
-#endif
-    }
-
-    void operator()(const snitch::event::test_case_skipped& e) const noexcept {
-        r.print(make_colored("skipped: ", r.with_color, color::skipped));
-        print_location(r, e.id, e.sections, e.captures, e.location);
-        r.print("          ", make_colored(e.message, r.with_color, color::highlight2), "\n");
-    }
-
-    void operator()(const snitch::event::assertion_failed& e) const noexcept {
-        if (e.expected) {
-            r.print(make_colored("expected failure: ", r.with_color, color::pass));
-        } else if (e.allowed) {
-            r.print(make_colored("allowed failure: ", r.with_color, color::pass));
-        } else {
-            r.print(make_colored("failed: ", r.with_color, color::fail));
-        }
-        print_location(r, e.id, e.sections, e.captures, e.location);
-        print_message(r, e.data);
-    }
-
-    void operator()(const snitch::event::assertion_succeeded& e) const noexcept {
-        r.print(make_colored("passed: ", r.with_color, color::pass));
-        print_location(r, e.id, e.sections, e.captures, e.location);
-        print_message(r, e.data);
-    }
-
-    void operator()(const snitch::event::list_test_run_started&) const noexcept {
-        r.print("Matching test cases:\n");
-    }
-
-    void operator()(const snitch::event::list_test_run_ended&) const noexcept {}
-
-    void operator()(const snitch::event::test_case_listed& e) {
-        small_string<max_test_name_length> full_name;
-        make_full_name(full_name, e.id);
-        r.print("  ", full_name, "\n");
-        if (!e.id.tags.empty()) {
-            r.print("      ", e.id.tags, "\n");
-        }
-    }
-};
 } // namespace
 
-void initialize(registry&) noexcept {}
+reporter::reporter(registry&) noexcept {}
 
-bool configure(registry& r, std::string_view option, std::string_view value) noexcept {
+bool reporter::configure(registry& r, std::string_view option, std::string_view value) noexcept {
     if (option == "color") {
         parse_color_option(r, value);
         return true;
@@ -203,14 +101,107 @@ bool configure(registry& r, std::string_view option, std::string_view value) noe
     return false;
 }
 
-void report(const registry& r, const event::data& event) noexcept {
-    std::visit(default_reporter_functor{r}, event);
+void reporter::report(const registry& r, const event::data& event) noexcept {
+    std::visit(
+        snitch::overload{
+            [&](const snitch::event::test_run_started& e) {
+                r.print(
+                    make_colored("starting ", r.with_color, color::highlight2),
+                    make_colored(e.name, r.with_color, color::highlight1),
+                    make_colored(" with ", r.with_color, color::highlight2),
+                    make_colored(
+                        "snitch v" SNITCH_FULL_VERSION "\n", r.with_color, color::highlight1));
+                r.print("==========================================\n");
+            },
+            [&](const snitch::event::test_run_ended& e) {
+                r.print("==========================================\n");
+
+                if (e.success) {
+                    r.print(
+                        make_colored("success:", r.with_color, color::pass), " all tests passed (",
+                        e.run_count, " test cases, ", e.assertion_count, " assertions");
+                } else {
+                    r.print(
+                        make_colored("error:", r.with_color, color::fail), " ",
+                        (e.fail_count == e.run_count ? "all" : "some"), " tests failed (",
+                        e.fail_count, " out of ", e.run_count, " test cases, ", e.assertion_count,
+                        " assertions");
+                }
+
+                if (e.skip_count > 0) {
+                    r.print(", ", e.skip_count, " test cases skipped");
+                }
+
+#if SNITCH_WITH_TIMINGS
+                r.print(", ", e.duration, " seconds");
+#endif
+
+                r.print(")\n");
+            },
+            [&](const snitch::event::test_case_started& e) {
+                small_string<max_test_name_length> full_name;
+                make_full_name(full_name, e.id);
+
+                r.print(
+                    make_colored("starting:", r.with_color, color::status), " ",
+                    make_colored(full_name, r.with_color, color::highlight1), " at ",
+                    e.location.file, ":", e.location.line, "\n");
+            },
+            [&](const snitch::event::test_case_ended& e) {
+                small_string<max_test_name_length> full_name;
+                make_full_name(full_name, e.id);
+
+#if SNITCH_WITH_TIMINGS
+                r.print(
+                    make_colored("finished:", r.with_color, color::status), " ",
+                    make_colored(full_name, r.with_color, color::highlight1), " (", e.duration,
+                    "s)\n");
+#else
+                r.print(
+                    make_colored("finished:", r.with_color, color::status), " ",
+                    make_colored(full_name, r.with_color, color::highlight1), "\n");
+#endif
+            },
+            [&](const snitch::event::test_case_skipped& e) {
+                r.print(make_colored("skipped: ", r.with_color, color::skipped));
+                print_location(r, e.id, e.sections, e.captures, e.location);
+                r.print(
+                    "          ", make_colored(e.message, r.with_color, color::highlight2), "\n");
+            },
+            [&](const snitch::event::assertion_failed& e) {
+                if (e.expected) {
+                    r.print(make_colored("expected failure: ", r.with_color, color::pass));
+                } else if (e.allowed) {
+                    r.print(make_colored("allowed failure: ", r.with_color, color::pass));
+                } else {
+                    r.print(make_colored("failed: ", r.with_color, color::fail));
+                }
+                print_location(r, e.id, e.sections, e.captures, e.location);
+                print_message(r, e.data);
+            },
+            [&](const snitch::event::assertion_succeeded& e) {
+                r.print(make_colored("passed: ", r.with_color, color::pass));
+                print_location(r, e.id, e.sections, e.captures, e.location);
+                print_message(r, e.data);
+            },
+            [&](const snitch::event::list_test_run_started&) {
+                r.print("Matching test cases:\n");
+                counter = 0;
+            },
+            [&](const snitch::event::list_test_run_ended&) {
+                r.print(counter, " matching test cases\n");
+            },
+            [&](const snitch::event::test_case_listed& e) {
+                small_string<max_test_name_length> full_name;
+                ++counter;
+                make_full_name(full_name, e.id);
+                r.print("  ", full_name, "\n");
+                if (!e.id.tags.empty()) {
+                    r.print("      ", e.id.tags, "\n");
+                }
+            }},
+        event);
 }
 } // namespace snitch::reporter::console
 
-SNITCH_REGISTER_REPORTER_CALLBACKS(
-    "console",
-    &snitch::reporter::console::initialize,
-    &snitch::reporter::console::configure,
-    &snitch::reporter::console::report,
-    {});
+SNITCH_REGISTER_REPORTER("console", snitch::reporter::console::reporter);

--- a/src/snitch_reporter_console.cpp
+++ b/src/snitch_reporter_console.cpp
@@ -203,5 +203,3 @@ void reporter::report(const registry& r, const event::data& event) noexcept {
         event);
 }
 } // namespace snitch::reporter::console
-
-SNITCH_REGISTER_REPORTER("console", snitch::reporter::console::reporter);

--- a/src/snitch_reporter_console.cpp
+++ b/src/snitch_reporter_console.cpp
@@ -86,8 +86,6 @@ void print_message(const registry& r, const assertion_data& data) {
 }
 } // namespace
 
-reporter::reporter(registry&) noexcept {}
-
 void reporter::init(registry&) noexcept {
     counter = 0;
 }

--- a/tests/approval_tests/data/expected/reporter_console_list_tests
+++ b/tests/approval_tests/data/expected/reporter_console_list_tests
@@ -53,3 +53,4 @@ Matching test cases:
   test SECTION
   test multiple SECTION
   test SECTION & INFO
+42 matching test cases

--- a/tests/approval_tests/reporter_console.cpp
+++ b/tests/approval_tests/reporter_console.cpp
@@ -13,9 +13,7 @@ TEST_CASE("console reporter", "[reporters]") {
     mock_framework framework;
     register_tests_for_reporters(framework.registry);
 
-    framework.registry.add_reporter(
-        "console", &snitch::reporter::console::initialize, &snitch::reporter::console::configure,
-        &snitch::reporter::console::report, {});
+    framework.registry.add_console_reporter();
 
     framework.registry.with_color = false;
 

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -534,7 +534,7 @@ SNITCH_WARNING_PUSH
 SNITCH_WARNING_DISABLE_PRECEDENCE
 SNITCH_WARNING_DISABLE_ASSIGNMENT
 
-#if defined(SNITCH_COMPILER_MSVC) && _MSC_VER >= 1937 && _MSC_VER <= 1938
+#if defined(__cpp_consteval) && __cpp_consteval <= 202211L
 // Regression in MSVC compiler
 // https://github.com/snitch-org/snitch/issues/140
 // https://developercommunity.visualstudio.com/t/Regression:-False-positive-C7595:-std::/10509214

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -583,10 +583,9 @@ TEST_CASE("list tests", "[registry]") {
             CAPTURE(tag);
             console.messages.clear();
 
-            const auto header = "Matching test cases:\n"sv;
-
             framework.registry.list_tests_with_tag(tag);
-            CHECK(console.messages == contains_substring(header));
+            CHECK(console.messages == contains_substring("Matching test cases:"));
+            CHECK(console.messages == contains_substring("matching test cases"));
             if (tag == "[tag]"sv) {
                 CHECK(console.messages == contains_substring("how are you"));
                 CHECK(console.messages == contains_substring("how many lights"));
@@ -621,7 +620,8 @@ TEST_CASE("list tests", "[registry]") {
                 CHECK(console.messages == contains_substring("how many templated lights"));
                 CHECK(console.messages == contains_substring("hidden test 1"));
             } else if (tag == "[wrong_tag]"sv || tag == "[.hidden]"sv) {
-                CHECK(console.messages == header);
+                const auto no_tests = "Matching test cases:\n0 matching test cases\n"sv;
+                CHECK(console.messages == no_tests);
             }
         }
     }

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -355,7 +355,6 @@ TEST_CASE("section readme example", "[test macros]") {
     };
 
     framework.registry.print_callback  = print;
-    framework.registry.report_callback = &snitch::reporter::console::report;
 
     framework.test_case.func = []() {
         auto& reg = snitch::impl::get_current_test().reg;

--- a/tests/testing_event.cpp
+++ b/tests/testing_event.cpp
@@ -229,9 +229,7 @@ std::optional<snitch::source_location> get_location(const owning_event::data& e)
 }
 
 mock_framework::mock_framework() noexcept {
-    registry.add_reporter(
-        "console", &snitch::reporter::console::initialize, &snitch::reporter::console::configure,
-        &snitch::reporter::console::report, {});
+    registry.add_console_reporter();
 
     registry.print_callback = [](std::string_view msg) noexcept {
         snitch::cli::console_print(msg);


### PR DESCRIPTION
This MR changes the console reporter from free functions to a struct, so that it can maintain state and count the
tests when listing them.

I am stuck trying to figure out how to properly initialize the `report_callback` in the registry. When the console report function was a free function it could just get a reference to that function. But now that it is a struct there needs to be an instance somewhere. The registry is `constinit` so there shouldn't be a static order issue, but it also can't have a non `constexpr` constructor.

Some tests also required a reporter instance, and there I declared one either in the test function itself or in an anonymous namespace in the test file if the lifetime needed to outlast the spot it was used.

