### PR TITLE
Draft: Feat/catch2 compat

### DIFF
--- a/include/snitch/snitch_section.hpp
+++ b/include/snitch/snitch_section.hpp
@@ -3,12 +3,21 @@
 
 #include "snitch/snitch_config.hpp"
 #include "snitch/snitch_test_data.hpp"
+#if SNITCH_WITH_TIMINGS
+#    include <chrono>
+#endif
 
 namespace snitch::impl {
 struct section_entry_checker {
     section     data = {};
     test_state& state;
-    bool        entered = false;
+    bool        entered          = false;
+    std::size_t asserts          = 0;
+    std::size_t failures         = 0;
+    std::size_t allowed_failures = 0;
+#if SNITCH_WITH_TIMINGS
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+#endif
 
     SNITCH_EXPORT ~section_entry_checker();
 

--- a/include/snitch/snitch_section.hpp
+++ b/include/snitch/snitch_section.hpp
@@ -3,9 +3,8 @@
 
 #include "snitch/snitch_config.hpp"
 #include "snitch/snitch_test_data.hpp"
-#if SNITCH_WITH_TIMINGS
-#    include <chrono>
-#endif
+
+#include <type_traits>
 
 namespace snitch::impl {
 struct section_entry_checker {
@@ -16,7 +15,7 @@ struct section_entry_checker {
     std::size_t failures         = 0;
     std::size_t allowed_failures = 0;
 #if SNITCH_WITH_TIMINGS
-    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    std::make_signed_t<std::size_t> start_time = 0;
 #endif
 
     SNITCH_EXPORT ~section_entry_checker();

--- a/include/snitch/snitch_test_data.hpp
+++ b/include/snitch/snitch_test_data.hpp
@@ -176,6 +176,27 @@ struct test_case_ended {
     bool failure_allowed  = false;
 };
 
+struct section_started {
+    /// Identifiers (name, description)
+    section_id id = {};
+    /// Location (file, line)
+    source_location location = {};
+};
+
+struct section_ended {
+    /// Identifiers (name, description)
+    section_id id = {};
+    /// Location (file, line)
+    source_location location                        = {};
+    bool            skipped                         = false;
+    std::size_t     assertion_count                 = 0;
+    std::size_t     assertion_failure_count         = 0;
+    std::size_t     allowed_assertion_failure_count = 0;
+#if SNITCH_WITH_TIMINGS
+    float duration = 0.0f;
+#endif
+};
+
 struct assertion_failed {
     const test_id&            id;
     section_info              sections = {};
@@ -231,6 +252,8 @@ using data = std::variant<
     test_run_ended,
     test_case_started,
     test_case_ended,
+    section_started,
+    section_ended,
     assertion_failed,
     assertion_succeeded,
     test_case_skipped,

--- a/src/snitch_reporter_catch2_xml.cpp
+++ b/src/snitch_reporter_catch2_xml.cpp
@@ -182,7 +182,7 @@ void reporter::report(const registry& r, const snitch::event::data& event) noexc
                     *this, r, "Catch2TestRun",
                     {{"name", make_escaped(e.name)},
                      {"rng-seed", "0"},
-                     {"xml-format-version", "2"},
+                     {"xml-format-version", "3"},
                      {"catch2-version", SNITCH_FULL_VERSION ".snitch"},
                      {"filters", make_filters(e.filters)}});
             },

--- a/src/snitch_reporter_console.cpp
+++ b/src/snitch_reporter_console.cpp
@@ -162,6 +162,8 @@ void reporter::report(const registry& r, const event::data& event) noexcept {
                     make_colored(full_name, r.with_color, color::highlight1), "\n");
 #endif
             },
+            [&](const snitch::event::section_started&) {},
+            [&](const snitch::event::section_ended&) {},
             [&](const snitch::event::test_case_skipped& e) {
                 r.print(make_colored("skipped: ", r.with_color, color::skipped));
                 print_location(r, e.id, e.sections, e.captures, e.location);

--- a/src/snitch_reporter_teamcity.cpp
+++ b/src/snitch_reporter_teamcity.cpp
@@ -148,6 +148,8 @@ void report(const registry& r, const snitch::event::data& event) noexcept {
                 send_message(r, "testFinished", {{"name", make_full_name(e.id)}});
 #    endif
             },
+            [&](const snitch::event::section_started&) {},
+            [&](const snitch::event::section_ended&) {},
             [&](const snitch::event::test_case_skipped& e) {
                 send_message(
                     r, "testIgnored",

--- a/src/snitch_section.cpp
+++ b/src/snitch_section.cpp
@@ -2,6 +2,7 @@
 
 #include "snitch/snitch_console.hpp"
 #include "snitch/snitch_registry.hpp"
+#include "snitch/snitch_test_data.hpp"
 
 #if SNITCH_WITH_EXCEPTIONS
 #    include <exception>
@@ -15,11 +16,19 @@ section_entry_checker::~section_entry_checker() {
             // We are unwinding the stack because an exception has been thrown;
             // avoid touching the section state since we will want to report where
             // the exception was thrown.
+            state.reg.report_callback(
+                state.reg, event::section_ended{
+                               state.sections.current_section.back().id,
+                               state.sections.current_section.back().location, true});
             return;
         }
 #endif
 
         pop_location(state);
+
+        asserts          = state.asserts - asserts;
+        failures         = state.failures - failures;
+        allowed_failures = state.allowed_failures - allowed_failures;
 
         if (state.sections.depth == state.sections.levels.size()) {
             // We just entered this section, and there was no child section in it.
@@ -29,6 +38,18 @@ section_entry_checker::~section_entry_checker() {
             // that we don't know about yet. Popping will be done when we exit from the parent,
             // since then we will know if there is any sibling.
             state.sections.leaf_executed = true;
+#if SNITCH_WITH_TIMINGS
+            const auto  end_time = std::chrono::steady_clock::now();
+            const float duration = std::chrono::duration<float>(end_time - start_time).count();
+            state.reg.report_callback(
+                state.reg,
+                event::section_ended{
+                    data.id, data.location, false, asserts, failures, allowed_failures, duration});
+#else
+            state.reg.report_callback(
+                state.reg,
+                event::section_ended{data.id, data.location, asserts, failures, allowed_failures});
+#endif
         } else {
             // Check if there is any child section left to execute, at any depth below this one.
             bool no_child_section_left = true;
@@ -42,6 +63,10 @@ section_entry_checker::~section_entry_checker() {
 
             if (no_child_section_left) {
                 // No more children, we can pop this level and never go back.
+                state.reg.report_callback(
+                    state.reg, event::section_ended{
+                                   state.sections.current_section.back().id,
+                                   state.sections.current_section.back().location});
                 state.sections.levels.pop_back();
             }
         }
@@ -68,6 +93,9 @@ section_entry_checker::operator bool() {
     }
 
     ++state.sections.depth;
+    asserts          = state.asserts;
+    failures         = state.failures;
+    allowed_failures = state.allowed_failures;
 
     auto& level = state.sections.levels[state.sections.depth - 1];
 
@@ -89,6 +117,10 @@ section_entry_checker::operator bool() {
         (level.current_section_id == level.previous_section_id &&
          state.sections.depth < state.sections.levels.size())) {
 
+        // First time entering this section, emit the section start event
+        if (level.current_section_id == level.previous_section_id + 1) {
+            state.reg.report_callback(state.reg, event::section_started{data.id, data.location});
+        }
         level.previous_section_id = level.current_section_id;
         state.sections.current_section.push_back(data);
         push_location(

--- a/src/snitch_section.cpp
+++ b/src/snitch_section.cpp
@@ -7,8 +7,16 @@
 #if SNITCH_WITH_EXCEPTIONS
 #    include <exception>
 #endif
+#if SNITCH_WITH_TIMINGS
+#    include <chrono>
+#endif
 
 namespace snitch::impl {
+#if SNITCH_WITH_TIMINGS
+using fsec         = std::chrono::duration<float>;
+using snitch_clock = std::chrono::steady_clock;
+#endif
+
 section_entry_checker::~section_entry_checker() {
     if (entered) {
 #if SNITCH_WITH_EXCEPTIONS
@@ -39,12 +47,13 @@ section_entry_checker::~section_entry_checker() {
             // since then we will know if there is any sibling.
             state.sections.leaf_executed = true;
 #if SNITCH_WITH_TIMINGS
-            const auto  end_time = std::chrono::steady_clock::now();
-            const float duration = std::chrono::duration<float>(end_time - start_time).count();
+            const auto end_time = snitch_clock::now().time_since_epoch();
+            const auto duration =
+                std::chrono::duration_cast<fsec>(end_time - snitch_clock::duration{start_time});
             state.reg.report_callback(
-                state.reg,
-                event::section_ended{
-                    data.id, data.location, false, asserts, failures, allowed_failures, duration});
+                state.reg, event::section_ended{
+                               data.id, data.location, false, asserts, failures, allowed_failures,
+                               duration.count()});
 #else
             state.reg.report_callback(
                 state.reg,
@@ -91,7 +100,9 @@ section_entry_checker::operator bool() {
 
         state.sections.levels.push_back({});
     }
-
+#if SNITCH_WITH_TIMINGS
+    start_time = snitch_clock::now().time_since_epoch().count();
+#endif
     ++state.sections.depth;
     asserts          = state.asserts;
     failures         = state.failures;

--- a/tests/approval_tests/data/expected/reporter_catch2_xml_allfail
+++ b/tests/approval_tests/data/expected/reporter_catch2_xml_allfail
@@ -10,13 +10,13 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test shouldfail good fail" tags="[tag2][tag1][!shouldfail]" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       expected test to fail
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test no tags fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -27,7 +27,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags fail &lt;int&gt;" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -38,7 +38,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags fail &lt;float&gt;" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -49,7 +49,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags fail &lt;int&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -60,7 +60,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags fail &lt;float&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -71,7 +71,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test fixture fail" tags="[tag with space]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -82,13 +82,13 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test FAIL fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       something bad
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test expression fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -99,7 +99,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test long expression fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -110,7 +110,7 @@
         1 == 1
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long expression fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -121,19 +121,19 @@
         super_long_string != super_long_string
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long message fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test NOTHROW fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       expected throw_something(true) not to throw but it threw a std::exception; message: I threw
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test THROW fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
@@ -145,38 +145,41 @@
     <Failure filename="*testing_reporters.cpp" line="*">
       could not match caught std::runtime_error with expected content: could not find &apos;I throws&apos; in &apos;I threw&apos;
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       unexpected std::exception caught; message: unexpected error
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw in section fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Section name="section 1" filename="*testing_reporters.cpp" line="*">
       <Section name="section 2" filename="*testing_reporters.cpp" line="*">
-        <Failure filename="*testing_reporters.cpp" line="*">
-          unexpected std::exception caught; message: unexpected error
-        </Failure>
+        <OverallResults successes="0" failures="0" expectedFailures="0" skipped="true" durationInSeconds="*"/>
       </Section>
+      <OverallResults successes="0" failures="0" expectedFailures="0" skipped="true" durationInSeconds="*"/>
     </Section>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <Failure filename="*testing_reporters.cpp" line="*">
+      unexpected std::exception caught; message: unexpected error
+    </Failure>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw in check fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       unexpected std::exception caught; message: unexpected error
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw in check &amp; section fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Section name="section 1" filename="*testing_reporters.cpp" line="*">
-      <Failure filename="*testing_reporters.cpp" line="*">
-        unexpected std::exception caught; message: unexpected error
-      </Failure>
+      <OverallResults successes="0" failures="0" expectedFailures="0" skipped="true" durationInSeconds="*"/>
     </Section>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <Failure filename="*testing_reporters.cpp" line="*">
+      unexpected std::exception caught; message: unexpected error
+    </Failure>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
-  <OverallResults successes="14" failures="21" expectedFailures="0"/>
-  <OverallResultsCases successes="0" failures="19" expectedFailures="0"/>
+  <OverallResults successes="14" failures="21" expectedFailures="0" skips="0"/>
+  <OverallResultsCases successes="0" failures="19" expectedFailures="0" skips="0"/>
 </Catch2TestRun>

--- a/tests/approval_tests/data/expected/reporter_catch2_xml_allpass
+++ b/tests/approval_tests/data/expected/reporter_catch2_xml_allpass
@@ -2,10 +2,10 @@
 
 <Catch2TestRun name="test" rng-seed="0" xml-format-version="2" catch2-version="*.snitch" filters="&quot;* pass*&quot;">
   <TestCase name="test pass" tags="[tag2][tag1]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test mayfail good pass" tags="[tag2][tag1][!mayfail]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test mayfail bad pass" tags="[tag2][tag1][!mayfail]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -16,7 +16,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test shouldfail bad pass" tags="[tag2][tag1][!shouldfail]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -27,50 +27,50 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test no tags pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags pass &lt;int&gt;" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags pass &lt;float&gt;" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags pass &lt;int&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags pass &lt;float&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test fixture pass" tags="[tag with space]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test SUCCEED pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test expression pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test long expression pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long expression pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long message pass" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test NOTHROW pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test THROW pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
-  <OverallResults successes="23" failures="1" expectedFailures="2"/>
-  <OverallResultsCases successes="14" failures="1" expectedFailures="2"/>
+  <OverallResults successes="23" failures="1" expectedFailures="2" skips="0"/>
+  <OverallResultsCases successes="14" failures="1" expectedFailures="2" skips="0"/>
 </Catch2TestRun>

--- a/tests/approval_tests/data/expected/reporter_catch2_xml_default
+++ b/tests/approval_tests/data/expected/reporter_catch2_xml_default
@@ -2,7 +2,7 @@
 
 <Catch2TestRun name="test" rng-seed="0" xml-format-version="2" catch2-version="*.snitch" filters="">
   <TestCase name="test pass" tags="[tag2][tag1]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test fail" tags="[tag2][tag1]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -13,10 +13,10 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test mayfail good pass" tags="[tag2][tag1][!mayfail]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test mayfail bad pass" tags="[tag2][tag1][!mayfail]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -27,13 +27,13 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test shouldfail good fail" tags="[tag2][tag1][!shouldfail]" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       expected test to fail
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test shouldfail bad pass" tags="[tag2][tag1][!shouldfail]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -44,10 +44,10 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test no tags pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test no tags fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -58,13 +58,13 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags pass &lt;int&gt;" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags pass &lt;float&gt;" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags fail &lt;int&gt;" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -75,7 +75,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test no tags fail &lt;float&gt;" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -86,13 +86,13 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags pass &lt;int&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags pass &lt;float&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags fail &lt;int&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -103,7 +103,7 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="typed test with tags fail &lt;float&gt;" tags="[tag1]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -114,10 +114,10 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test fixture pass" tags="[tag with space]" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test fixture fail" tags="[tag with space]" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -128,19 +128,19 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test SUCCEED pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test FAIL fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       something bad
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test expression pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test expression fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -151,10 +151,10 @@
         1 != 2
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test long expression pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test long expression fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -165,10 +165,10 @@
         1 == 1
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long expression pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long expression fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Expression success="false" type="CHECK" filename="*testing_reporters.cpp" line="*">
@@ -179,31 +179,31 @@
         super_long_string != super_long_string
       </Expanded>
     </Expression>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long message pass" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test too long message fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test NOTHROW pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test NOTHROW fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       expected throw_something(true) not to throw but it threw a std::exception; message: I threw
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test THROW pass" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <OverallResult success="true" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test THROW fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
@@ -215,40 +215,46 @@
     <Failure filename="*testing_reporters.cpp" line="*">
       could not match caught std::runtime_error with expected content: could not find &apos;I throws&apos; in &apos;I threw&apos;
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       unexpected std::exception caught; message: unexpected error
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw in section fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Section name="section 1" filename="*testing_reporters.cpp" line="*">
       <Section name="section 2" filename="*testing_reporters.cpp" line="*">
-        <Failure filename="*testing_reporters.cpp" line="*">
-          unexpected std::exception caught; message: unexpected error
-        </Failure>
+        <OverallResults successes="0" failures="0" expectedFailures="0" skipped="true" durationInSeconds="*"/>
       </Section>
+      <OverallResults successes="0" failures="0" expectedFailures="0" skipped="true" durationInSeconds="*"/>
     </Section>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <Failure filename="*testing_reporters.cpp" line="*">
+      unexpected std::exception caught; message: unexpected error
+    </Failure>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw in check fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
       unexpected std::exception caught; message: unexpected error
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test unexpected throw in check &amp; section fail" tags="" filename="*testing_reporters.cpp" line="*">
     <Section name="section 1" filename="*testing_reporters.cpp" line="*">
-      <Failure filename="*testing_reporters.cpp" line="*">
-        unexpected std::exception caught; message: unexpected error
-      </Failure>
+      <OverallResults successes="0" failures="0" expectedFailures="0" skipped="true" durationInSeconds="*"/>
     </Section>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <Failure filename="*testing_reporters.cpp" line="*">
+      unexpected std::exception caught; message: unexpected error
+    </Failure>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test SKIP" tags="" filename="*testing_reporters.cpp" line="*">
-    <OverallResult success="true" durationInSeconds="*"/>
+    <Skip filename="*testing_reporters.cpp" line="*">
+      not interesting
+    </Skip>
+    <OverallResult success="true" skips="1" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test INFO" tags="" filename="*testing_reporters.cpp" line="*">
     <Info>
@@ -257,7 +263,7 @@
     <Failure filename="*testing_reporters.cpp" line="*">
       failure
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test multiple INFO" tags="" filename="*testing_reporters.cpp" line="*">
     <Failure filename="*testing_reporters.cpp" line="*">
@@ -284,21 +290,23 @@
     <Failure filename="*testing_reporters.cpp" line="*">
       failure 4
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test SECTION" tags="" filename="*testing_reporters.cpp" line="*">
     <Section name="section" filename="*testing_reporters.cpp" line="*">
       <Failure filename="*testing_reporters.cpp" line="*">
         failure
       </Failure>
+      <OverallResults successes="0" failures="1" expectedFailures="0" skipped="false" durationInSeconds="*"/>
     </Section>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test multiple SECTION" tags="" filename="*testing_reporters.cpp" line="*">
     <Section name="section 1" filename="*testing_reporters.cpp" line="*">
       <Failure filename="*testing_reporters.cpp" line="*">
         failure 1
       </Failure>
+      <OverallResults successes="0" failures="1" expectedFailures="0" skipped="false" durationInSeconds="*"/>
     </Section>
     <Failure filename="*testing_reporters.cpp" line="*">
       failure 7
@@ -307,49 +315,39 @@
       <Failure filename="*testing_reporters.cpp" line="*">
         failure 2
       </Failure>
-    </Section>
-    <Section name="section 2" filename="*testing_reporters.cpp" line="*">
       <Section name="section 2.1" filename="*testing_reporters.cpp" line="*">
         <Failure filename="*testing_reporters.cpp" line="*">
           failure 3
         </Failure>
+        <OverallResults successes="0" failures="1" expectedFailures="0" skipped="false" durationInSeconds="*"/>
       </Section>
-    </Section>
-    <Failure filename="*testing_reporters.cpp" line="*">
-      failure 7
-    </Failure>
-    <Section name="section 2" filename="*testing_reporters.cpp" line="*">
+      <Failure filename="*testing_reporters.cpp" line="*">
+        failure 7
+      </Failure>
       <Failure filename="*testing_reporters.cpp" line="*">
         failure 2
       </Failure>
-    </Section>
-    <Section name="section 2" filename="*testing_reporters.cpp" line="*">
       <Section name="section 2.2" filename="*testing_reporters.cpp" line="*">
         <Failure filename="*testing_reporters.cpp" line="*">
           failure 4
         </Failure>
-      </Section>
-    </Section>
-    <Section name="section 2" filename="*testing_reporters.cpp" line="*">
-      <Section name="section 2.2" filename="*testing_reporters.cpp" line="*">
         <Section name="section 2.2.1" filename="*testing_reporters.cpp" line="*">
           <Failure filename="*testing_reporters.cpp" line="*">
             failure 5
           </Failure>
+          <OverallResults successes="0" failures="1" expectedFailures="0" skipped="false" durationInSeconds="*"/>
         </Section>
-      </Section>
-    </Section>
-    <Section name="section 2" filename="*testing_reporters.cpp" line="*">
-      <Section name="section 2.2" filename="*testing_reporters.cpp" line="*">
         <Failure filename="*testing_reporters.cpp" line="*">
           failure 6
         </Failure>
+        <OverallResults successes="0" failures="0" expectedFailures="0" skipped="false" durationInSeconds="*"/>
       </Section>
+      <OverallResults successes="0" failures="0" expectedFailures="0" skipped="false" durationInSeconds="*"/>
     </Section>
     <Failure filename="*testing_reporters.cpp" line="*">
       failure 7
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test SECTION &amp; INFO" tags="" filename="*testing_reporters.cpp" line="*">
     <Section name="section 1" filename="*testing_reporters.cpp" line="*">
@@ -362,6 +360,7 @@
       <Failure filename="*testing_reporters.cpp" line="*">
         failure 1
       </Failure>
+      <OverallResults successes="0" failures="1" expectedFailures="0" skipped="false" durationInSeconds="*"/>
     </Section>
     <Info>
       info 1
@@ -379,6 +378,7 @@
       <Failure filename="*testing_reporters.cpp" line="*">
         failure 2
       </Failure>
+      <OverallResults successes="0" failures="1" expectedFailures="0" skipped="false" durationInSeconds="*"/>
     </Section>
     <Info>
       info 1
@@ -386,20 +386,20 @@
     <Failure filename="*testing_reporters.cpp" line="*">
       failure 3
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test escape &lt;&gt;&amp;&quot;&apos;" tags="" filename="*reporter_catch2_xml.cpp" line="*">
     <Failure filename="*reporter_catch2_xml.cpp" line="*">
       escape &lt;&gt;&amp;&quot;&apos; in messages
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
   <TestCase name="test escape very long" tags="" filename="*reporter_catch2_xml.cpp" line="*">
     <Failure filename="*reporter_catch2_xml.cpp" line="*">
       &amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;...
     </Failure>
-    <OverallResult success="false" durationInSeconds="*"/>
+    <OverallResult success="false" skips="0" durationInSeconds="*"/>
   </TestCase>
-  <OverallResults successes="42" failures="44" expectedFailures="2"/>
-  <OverallResultsCases successes="15" failures="27" expectedFailures="2"/>
+  <OverallResults successes="42" failures="44" expectedFailures="2" skips="1"/>
+  <OverallResultsCases successes="15" failures="27" expectedFailures="2" skips="1"/>
 </Catch2TestRun>

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -1765,7 +1765,7 @@ SNITCH_WARNING_PUSH
 SNITCH_WARNING_DISABLE_UNREACHABLE
 
 TEST_CASE("unhandled exceptions", "[test macros]") {
-    event_catcher<3> catcher;
+    event_catcher<7> catcher;
 
     test_check_line   = 0u;
     test_section_line = 0u;

--- a/tests/testing_event.cpp
+++ b/tests/testing_event.cpp
@@ -141,6 +141,27 @@ owning_event::data deep_copy(snitch::small_string_span pool, const snitch::event
                 c.failure_allowed  = s.failure_allowed;
                 return c;
             },
+            [&](const snitch::event::section_started& s) -> owning_event::data {
+                owning_event::section_started c;
+                copy_location(pool, c, s);
+                c.id.name        = append_to_pool(pool, s.id.name);
+                c.id.description = append_to_pool(pool, s.id.description);
+                return c;
+            },
+            [&](const snitch::event::section_ended& s) -> owning_event::data {
+                owning_event::section_ended c;
+                copy_location(pool, c, s);
+                c.id.name                         = append_to_pool(pool, s.id.name);
+                c.id.description                  = append_to_pool(pool, s.id.description);
+                c.skipped                         = s.skipped;
+                c.assertion_count                 = s.assertion_count;
+                c.assertion_failure_count         = s.assertion_failure_count;
+                c.allowed_assertion_failure_count = s.allowed_assertion_failure_count;
+#if SNITCH_WITH_TIMINGS
+                c.duration = s.duration;
+#endif
+                return c;
+            },
             [&](const snitch::event::test_run_started& s) -> owning_event::data {
                 owning_event::test_run_started c;
                 copy_test_run_id(pool, c, s);

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -53,6 +53,23 @@ struct test_case_ended {
     bool failure_allowed  = false;
 };
 
+struct section_started {
+    snitch::section_id      id       = {};
+    snitch::source_location location = {};
+};
+
+struct section_ended {
+    snitch::section_id      id       = {};
+    snitch::source_location location = {};
+    bool            skipped                         = false;
+    std::size_t     assertion_count                 = 0;
+    std::size_t     assertion_failure_count         = 0;
+    std::size_t     allowed_assertion_failure_count = 0;
+#if SNITCH_WITH_TIMINGS
+    float duration = 0.0f;
+#endif
+};
+
 struct assertion_failed {
     snitch::test_id         id       = {};
     section_info            sections = {};
@@ -99,6 +116,8 @@ using data = std::variant<
     owning_event::test_run_ended,
     owning_event::test_case_started,
     owning_event::test_case_ended,
+    owning_event::section_started,
+    owning_event::section_ended,
     owning_event::assertion_failed,
     owning_event::assertion_succeeded,
     owning_event::test_case_skipped,


### PR DESCRIPTION
Very rought draft, but I wanted to open it so others can look and comment.

This is work to make the Catch2 XML output match up with Catch2. Like the other open MRs I notices this when integrating with my teams IDE and (more importantly) CI test reporting systems. 

Without these changes CI and IDEs work ok, but failures in a section just fail the whole test. When we were using Catch2 a failure would be specific to a section allowing us to quickly drill down to the problem. So looking into the difference it is just the lack of section output in the "high" verbosity mode. Catch2 outputs section XML data by default.

It was fairly easy to make it work with basic testing, pass and fail. There are more complex edge cases around skips, nested sections, exceptions being thrown, and different verbosity levels. I am still ironing those out and need to make sure there is testing for it all.

As I have time this week i will add some examples here, and some pictures to show the different in CI/IDEs.