### PR TITLE
Fix capture/section state after unhandled exception(s)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,12 +6,12 @@ coverage:
   round: down
   range: "80...95"
   status:
-  project:
-    default:
-      target: auto
-      # adjust accordingly based on how flaky your tests are
-      # this allows a drop from the previous base commit coverage
-      threshold: 1%
+    project:
+      default:
+        target: auto
+        # adjust accordingly based on how flaky your tests are
+        # this allows a drop from the previous base commit coverage
+        threshold: 1%
     patch:
       default:
         target: 0%

--- a/include/snitch/snitch_capture.hpp
+++ b/include/snitch/snitch_capture.hpp
@@ -14,7 +14,7 @@ struct scoped_capture {
     capture_state& captures;
     std::size_t    count = 0;
 
-    ~scoped_capture();
+    SNITCH_EXPORT ~scoped_capture();
 };
 
 SNITCH_EXPORT std::string_view extract_next_name(std::string_view& names) noexcept;

--- a/include/snitch/snitch_capture.hpp
+++ b/include/snitch/snitch_capture.hpp
@@ -14,9 +14,7 @@ struct scoped_capture {
     capture_state& captures;
     std::size_t    count = 0;
 
-    ~scoped_capture() {
-        captures.resize(captures.size() - count);
-    }
+    ~scoped_capture();
 };
 
 SNITCH_EXPORT std::string_view extract_next_name(std::string_view& names) noexcept;

--- a/include/snitch/snitch_capture.hpp
+++ b/include/snitch/snitch_capture.hpp
@@ -11,10 +11,7 @@
 
 namespace snitch::impl {
 struct scoped_capture {
-    capture_state& captures;
-#if SNITCH_WITH_EXCEPTIONS
-    std::optional<capture_state>& held_captures;
-#endif
+    test_state& state;
     std::size_t count = 0;
 
     SNITCH_EXPORT ~scoped_capture();
@@ -38,11 +35,7 @@ void add_capture(test_state& state, std::string_view& names, const T& arg) {
 template<string_appendable... Args>
 scoped_capture add_captures(test_state& state, std::string_view names, const Args&... args) {
     (add_capture(state, names, args), ...);
-#if SNITCH_WITH_EXCEPTIONS
-    return {state.captures, state.held_captures, sizeof...(args)};
-#else
-    return {state.captures, sizeof...(args)};
-#endif
+    return {state, sizeof...(args)};
 }
 
 // Requires: number of captures < max_captures.
@@ -50,11 +43,7 @@ template<string_appendable... Args>
 scoped_capture add_info(test_state& state, const Args&... args) {
     auto& capture = add_capture(state);
     append_or_truncate(capture, args...);
-#if SNITCH_WITH_EXCEPTIONS
-    return {state.captures, state.held_captures, 1};
-#else
-    return {state.captures, 1};
-#endif
+    return {state, 1};
 }
 } // namespace snitch::impl
 

--- a/include/snitch/snitch_string_utility.hpp
+++ b/include/snitch/snitch_string_utility.hpp
@@ -42,13 +42,20 @@ constexpr small_string<N> resize_or_truncate(const small_string<M>& str) noexcep
         return str;
     } else if constexpr (N > M) {
         small_string<N> out;
-        append(out, str);
+        append(out, std::string_view{str});
         return out;
     } else {
         small_string<N> out;
-        append_or_truncate(out, str);
+        append_or_truncate(out, std::string_view{str});
         return out;
     }
+}
+
+template<std::size_t N, std::size_t M>
+constexpr small_string<N> resize_or_truncate(std::string_view str) noexcept {
+    small_string<N> out;
+    append(out, str);
+    return out;
 }
 
 SNITCH_EXPORT [[nodiscard]] bool replace_all(

--- a/include/snitch/snitch_test_data.hpp
+++ b/include/snitch/snitch_test_data.hpp
@@ -279,15 +279,20 @@ using capture_state = small_vector<small_string<max_capture_length>, max_capture
 // NB: +2 is because we need one for the test case location, and one for the check location
 using location_state = small_vector<assertion_location, max_nested_sections + 2>;
 
-struct test_state {
-    registry&      reg;
-    test_case&     test;
+struct info_state {
     section_state  sections  = {};
     capture_state  captures  = {};
     location_state locations = {};
+};
+
+struct test_state {
+    registry&  reg;
+    test_case& test;
+
+    info_state info = {};
 
 #if SNITCH_WITH_EXCEPTIONS
-    std::optional<capture_state> held_captures = {};
+    std::optional<info_state> held_info = {};
 #endif
 
     std::size_t asserts          = 0;

--- a/include/snitch/snitch_test_data.hpp
+++ b/include/snitch/snitch_test_data.hpp
@@ -6,6 +6,7 @@
 #include "snitch/snitch_vector.hpp"
 
 #include <cstddef>
+#include <optional>
 #include <string_view>
 
 namespace snitch {
@@ -285,12 +286,20 @@ struct test_state {
     capture_state  captures  = {};
     location_state locations = {};
 
+#if SNITCH_WITH_EXCEPTIONS
+    std::optional<capture_state> held_captures = {};
+#endif
+
     std::size_t asserts          = 0;
     std::size_t failures         = 0;
     std::size_t allowed_failures = 0;
     bool        may_fail         = false;
     bool        should_fail      = false;
     bool        in_check         = false;
+
+#if SNITCH_WITH_EXCEPTIONS
+    bool unhandled_exception = false;
+#endif
 
 #if SNITCH_WITH_TIMINGS
     float duration = 0.0f;

--- a/src/snitch_capture.cpp
+++ b/src/snitch_capture.cpp
@@ -22,11 +22,11 @@ void trim(std::string_view& str, std::string_view patterns) noexcept {
 
 scoped_capture::~scoped_capture() {
 #if SNITCH_WITH_EXCEPTIONS
-    if (std::uncaught_exceptions() > 0) {
+    if (std::uncaught_exceptions() > 0 && !held_captures.has_value()) {
         // We are unwinding the stack because an exception has been thrown;
-        // avoid touching the capture state since we will want to preserve the information
+        // keep a copy of the full capture state since we will want to preserve the information
         // when reporting the exception.
-        return;
+        held_captures = captures;
     }
 #endif
 
@@ -90,6 +90,10 @@ small_string<max_capture_length>& add_capture(test_state& state) {
             max_captures, ")\n.");
         assertion_failed("max number of captures reached");
     }
+
+#if SNITCH_WITH_EXCEPTIONS
+    state.held_captures.reset();
+#endif
 
     state.captures.grow(1);
     state.captures.back().clear();

--- a/src/snitch_capture.cpp
+++ b/src/snitch_capture.cpp
@@ -22,15 +22,15 @@ void trim(std::string_view& str, std::string_view patterns) noexcept {
 
 scoped_capture::~scoped_capture() {
 #if SNITCH_WITH_EXCEPTIONS
-    if (std::uncaught_exceptions() > 0 && !held_captures.has_value()) {
+    if (std::uncaught_exceptions() > 0 && !state.held_info.has_value()) {
         // We are unwinding the stack because an exception has been thrown;
         // keep a copy of the full capture state since we will want to preserve the information
         // when reporting the exception.
-        held_captures = captures;
+        state.held_info = state.info;
     }
 #endif
 
-    captures.resize(captures.size() - count);
+    state.info.captures.resize(state.info.captures.size() - count);
 }
 
 std::string_view extract_next_name(std::string_view& names) noexcept {
@@ -82,7 +82,7 @@ std::string_view extract_next_name(std::string_view& names) noexcept {
 }
 
 small_string<max_capture_length>& add_capture(test_state& state) {
-    if (state.captures.available() == 0) {
+    if (state.info.captures.available() == 0) {
         state.reg.print(
             make_colored("error:", state.reg.with_color, color::fail),
             " max number of captures reached; "
@@ -92,11 +92,11 @@ small_string<max_capture_length>& add_capture(test_state& state) {
     }
 
 #if SNITCH_WITH_EXCEPTIONS
-    state.held_captures.reset();
+    state.held_info.reset();
 #endif
 
-    state.captures.grow(1);
-    state.captures.back().clear();
-    return state.captures.back();
+    state.info.captures.grow(1);
+    state.info.captures.back().clear();
+    return state.info.captures.back();
 }
 } // namespace snitch::impl

--- a/src/snitch_capture.cpp
+++ b/src/snitch_capture.cpp
@@ -20,6 +20,19 @@ void trim(std::string_view& str, std::string_view patterns) noexcept {
 }
 } // namespace
 
+scoped_capture::~scoped_capture() {
+#if SNITCH_WITH_EXCEPTIONS
+    if (std::uncaught_exceptions() > 0) {
+        // We are unwinding the stack because an exception has been thrown;
+        // avoid touching the capture state since we will want to preserve the information
+        // when reporting the exception.
+        return;
+    }
+#endif
+
+    captures.resize(captures.size() - count);
+}
+
 std::string_view extract_next_name(std::string_view& names) noexcept {
     std::string_view result;
 

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -207,6 +207,7 @@ TEST_CASE("capture", "[test macros]") {
         };
 
         framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_CAPTURES("j := 2");
     }
 
@@ -224,6 +225,7 @@ TEST_CASE("capture", "[test macros]") {
         };
 
         framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_NO_CAPTURE;
     }
 
@@ -249,6 +251,7 @@ TEST_CASE("capture", "[test macros]") {
         };
 
         framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_CAPTURES("k := 3");
     }
 
@@ -267,6 +270,7 @@ TEST_CASE("capture", "[test macros]") {
         };
 
         framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_CAPTURES("j := 2");
     }
 
@@ -283,7 +287,9 @@ TEST_CASE("capture", "[test macros]") {
         };
 
         framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
         // FIXME: expected nothing
+        // https://github.com/snitch-org/snitch/issues/179
         CHECK_CAPTURES("i := 1");
     }
 #endif

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -191,6 +191,101 @@ TEST_CASE("capture", "[test macros]") {
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_CAPTURES_FOR_FAILURE(0u, "i := 1");
     }
+
+    SECTION("with handled exception") {
+        framework.test_case.func = []() {
+            try {
+                int i = 1;
+                SNITCH_CAPTURE(i);
+                throw std::runtime_error("bad");
+            } catch (...) {
+            }
+
+            int j = 2;
+            SNITCH_CAPTURE(j);
+            SNITCH_CHECK(j == 1);
+        };
+
+        framework.run_test();
+        CHECK_CAPTURES("j := 2");
+    }
+
+    SECTION("with handled exception no capture") {
+        framework.test_case.func = []() {
+            try {
+                int i = 1;
+                SNITCH_CAPTURE(i);
+                throw std::runtime_error("bad");
+            } catch (...) {
+            }
+
+            int j = 2;
+            SNITCH_CHECK(j == 1);
+        };
+
+        framework.run_test();
+        CHECK_NO_CAPTURE;
+    }
+
+    SECTION("with handled exceptions") {
+        framework.test_case.func = []() {
+            try {
+                int i = 1;
+                SNITCH_CAPTURE(i);
+                throw std::runtime_error("bad");
+            } catch (...) {
+            }
+
+            try {
+                int j = 2;
+                SNITCH_CAPTURE(j);
+                throw std::runtime_error("bad");
+            } catch (...) {
+            }
+
+            int k = 3;
+            SNITCH_CAPTURE(k);
+            SNITCH_CHECK(k == 1);
+        };
+
+        framework.run_test();
+        CHECK_CAPTURES("k := 3");
+    }
+
+    SECTION("with handled exception then unhandled") {
+        framework.test_case.func = []() {
+            try {
+                int i = 1;
+                SNITCH_CAPTURE(i);
+                throw std::runtime_error("bad");
+            } catch (...) {
+            }
+
+            int j = 2;
+            SNITCH_CAPTURE(j);
+            throw std::runtime_error("bad");
+        };
+
+        framework.run_test();
+        CHECK_CAPTURES("j := 2");
+    }
+
+    SECTION("with handled exception then unhandled no capture") {
+        framework.test_case.func = []() {
+            try {
+                int i = 1;
+                SNITCH_CAPTURE(i);
+                throw std::runtime_error("bad");
+            } catch (...) {
+            }
+
+            throw std::runtime_error("bad");
+        };
+
+        framework.run_test();
+        // FIXME: expected nothing
+        CHECK_CAPTURES("i := 1");
+    }
 #endif
 }
 

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -2,6 +2,9 @@
 #include "testing_event.hpp"
 
 #include <string>
+#if SNITCH_WITH_EXCEPTIONS
+#    include <stdexcept>
+#endif
 
 using namespace std::literals;
 

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -171,6 +171,24 @@ TEST_CASE("capture", "[test macros]") {
         CHECK_CAPTURES_FOR_FAILURE(0u, "i := 1");
         CHECK_CAPTURES_FOR_FAILURE(1u, "i := 1", "2 * i := 2");
     }
+
+#if SNITCH_WITH_EXCEPTIONS
+    SECTION("with exception") {
+        framework.test_case.func = []() {
+            for (std::size_t i = 0; i < 5; ++i) {
+                SNITCH_CAPTURE(i);
+
+                if (i % 2 == 1) {
+                    throw std::runtime_error("bad");
+                }
+            }
+        };
+
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
+        CHECK_CAPTURES_FOR_FAILURE(0u, "i := 1");
+    }
+#endif
 }
 
 TEST_CASE("info", "[test macros]") {
@@ -324,6 +342,24 @@ TEST_CASE("info", "[test macros]") {
         framework.run_test();
         CHECK_CAPTURES("1", "i := 1");
     }
+
+#if SNITCH_WITH_EXCEPTIONS
+    SECTION("with exception") {
+        framework.test_case.func = []() {
+            for (std::size_t i = 0; i < 5; ++i) {
+                SNITCH_INFO(i);
+
+                if (i % 2 == 1) {
+                    throw std::runtime_error("bad");
+                }
+            }
+        };
+
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
+        CHECK_CAPTURES_FOR_FAILURE(0u, "1");
+    }
+#endif
 }
 
 SNITCH_WARNING_POP

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -354,7 +354,7 @@ TEST_CASE("section readme example", "[test macros]") {
         }
     };
 
-    framework.registry.print_callback  = print;
+    framework.registry.print_callback = print;
 
     framework.test_case.func = []() {
         auto& reg = snitch::impl::get_current_test().reg;

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -336,6 +336,106 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS("section 2");
         CHECK_CASE(snitch::test_case_state::failed, 1u, 1u);
     }
+
+    SECTION("with handled exception") {
+        framework.test_case.func = []() {
+            try {
+                SNITCH_SECTION("section 1") {
+                    throw std::runtime_error("bad");
+                }
+            } catch (...) {
+            }
+
+            SNITCH_SECTION("section 2") {
+                SNITCH_FAIL_CHECK("trigger");
+            }
+        };
+
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
+        CHECK_SECTIONS("section 2");
+    }
+
+    SECTION("with handled exception no section") {
+        framework.test_case.func = []() {
+            try {
+                SNITCH_SECTION("section 1") {
+                    throw std::runtime_error("bad");
+                }
+            } catch (...) {
+            }
+
+            SNITCH_FAIL_CHECK("trigger");
+        };
+
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
+        CHECK_NO_SECTION;
+    }
+
+    SECTION("with handled exceptions") {
+        framework.test_case.func = []() {
+            try {
+                SNITCH_SECTION("section 1") {
+                    throw std::runtime_error("bad");
+                }
+            } catch (...) {
+            }
+
+            try {
+                SNITCH_SECTION("section 2") {
+                    throw std::runtime_error("bad");
+                }
+            } catch (...) {
+            }
+
+            SNITCH_SECTION("section 3") {
+                SNITCH_FAIL_CHECK("trigger");
+            }
+        };
+
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
+        CHECK_SECTIONS("section 3");
+    }
+
+    SECTION("with handled exception then unhandled") {
+        framework.test_case.func = []() {
+            try {
+                SNITCH_SECTION("section 1") {
+                    throw std::runtime_error("bad");
+                }
+            } catch (...) {
+            }
+
+            SNITCH_SECTION("section 2") {
+                throw std::runtime_error("bad");
+            }
+        };
+
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
+        CHECK_SECTIONS("section 2");
+    }
+
+    SECTION("with handled exception then unhandled no section") {
+        framework.test_case.func = []() {
+            try {
+                SNITCH_SECTION("section 1") {
+                    throw std::runtime_error("bad");
+                }
+            } catch (...) {
+            }
+
+            throw std::runtime_error("bad");
+        };
+
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
+        // FIXME: expected nothing
+        // https://github.com/snitch-org/snitch/issues/179
+        CHECK_SECTIONS("section 1");
+    }
 #endif
 }
 


### PR DESCRIPTION
This PR does the following:
 - Fix #177 by checking for unhandled exception before popping capture data that goes out of scope. This also affected `SECTION`.
 - Add explicit casts in internal code to avoid potential ambiguous calls to `append()` when user defines their own overloads.
 - Fix the codecov configuration.