### PR TITLE
Add base for workflow uploading release artifacts

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -193,19 +193,10 @@ jobs:
       shell: bash
       run: cmake --build . --config ${{matrix.build-type}} --target install
 
-    # In action-zip, all paths are relative to ${{github.workspace}}
-    - name: Zip build
-      if: matrix.build-type == 'Release' && matrix.platform.publish && github.ref == 'refs/heads/main'
-      uses: vimtor/action-zip@v1
-      with:
-        files: install/ LICENSE
-        dest: snitch-${{matrix.platform.build}}.zip
-
     - name: Upload build as an artifact
       if: matrix.build-type == 'Release' && matrix.platform.publish && github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v4
       with:
         name: snitch-${{matrix.platform.build}}
-        path: |
-          ${{github.workspace}}/snitch-${{matrix.platform.build}}.zip
+        path: ${{github.workspace}}/install
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -115,7 +115,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2 # necessary for codecov bash uploader
         submodules: 'recursive'
@@ -127,14 +127,14 @@ jobs:
     - name: Setup Emscripten cache
       if: matrix.platform.compiler == 'em++'
       id: cache-system-libraries
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v4
       with:
         path: ${{env.EM_CACHE_FOLDER}}
         key: ${{env.EM_VERSION}}-${{matrix.platform.name}}-${{matrix.build-type}}
 
     - name: Setup Emscripten
       if: matrix.platform.compiler == 'em++'
-      uses: mymindstorm/setup-emsdk@v12
+      uses: mymindstorm/setup-emsdk@v14
       with:
         version: ${{env.EM_VERSION}}
         actions-cache-folder: ${{env.EM_CACHE_FOLDER}}

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Clang
       if: matrix.platform.compiler == 'clang-15' && matrix.platform.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release artifacts
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+    name: Publish artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare artifacts
+        run:
+
+      - name: Upload artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,15 @@ jobs:
     name: Publish artifacts
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Prepare artifacts
-        run:
+      - name: Fetch artifacts
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: cmake.yml
+          branch: main
+          skip_unpack: true
+          allow_forks: false
 
       - name: Upload artifacts
         uses: softprops/action-gh-release@v2
         with:
-          files:
+          files: '*.zip'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(snitch LANGUAGES CXX VERSION 1.3.1)
+project(snitch LANGUAGES CXX VERSION 1.3.2)
 
 # Maximum lengths.
 set(SNITCH_MAX_TEST_CASES           5000 CACHE STRING "Maximum number of test cases in a test application.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,10 @@ else()
         DESTINATION include/snitch)
 endif()
 
+install(
+    FILES ${PROJECT_SOURCE_DIR}/LICENSE
+    DESTINATION doc/snitch)
+
 # Common properties
 add_library(snitch::${SNITCH_TARGET_NAME} ALIAS ${SNITCH_TARGET_NAME})
 set_target_properties(${SNITCH_TARGET_NAME} PROPERTIES EXPORT_NAME snitch::${SNITCH_TARGET_NAME})

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('snitch', 'cpp',
   default_options: ['cpp_std=c++20', 'default_library=static'],
-  version: '1.3.1'
+  version: '1.3.2'
 )
 
 cpp_arguments = []


### PR DESCRIPTION
This is related to https://github.com/snitch-org/snitch/issues/175.

I am not sure how the release artifacts are prepared (the single-file header-only one I think I can figure out) or whether the zip file inside of zip file is intentional, but this workflow should allow performing the necessary steps to automate the upload of release artifacts.

It will execute automatically on published release.

The "Prepare artifacts" step can be used to generate the necessary zip files. The "Upload artifacts" step can be used to upload the prepared files. `with.files` can be filled like this:
```
with:
  files: |
    snitch-header-only.zip
    snitch-ubuntu64-libc++-static.zip
    snitch-ubuntu64-libstdc++-static.zip
    # etc.
```